### PR TITLE
feat: show Colony/Platinum card counts based on player count

### DIFF
--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -595,6 +595,15 @@ export default function Suggester() {
             </div>
           )}
 
+          {/* Colony + Platinum count reminder */}
+          {colonyPlatinum && colonyCard && platinumCard && (
+            <div style={{ marginBottom: '1rem' }}>
+              <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em' }}>
+                Velmegun — {formatColonyPlatinumLabel(showAdvanced ? selectedPlayers.length : 0)}
+              </div>
+            </div>
+          )}
+
           {/* 10 Kingdom Cards */}
           <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: '.75rem' }}>
             Ríkið — {kingdom.length} spil
@@ -623,7 +632,7 @@ export default function Suggester() {
           {colonyPlatinum && colonyCard && platinumCard && (
             <div style={{ marginTop: '1.5rem' }}>
               <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: '.75rem' }}>
-                Velmegun — {formatColonyPlatinumLabel(showAdvanced ? selectedPlayers.length : 0)}
+                Velmegun — Colony &amp; Platinum
               </div>
               <div className="kingdom-display">
                 {[colonyCard, platinumCard].map(card => (

--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -70,6 +70,12 @@ function formatCost(card) {
   return `${card.cost}`
 }
 
+function formatColonyPlatinumLabel(playerCount) {
+  const colonyCount = playerCount >= 2 ? (playerCount === 2 ? 8 : 12) : null
+  const colonyLabel = colonyCount != null ? `Colony (${colonyCount})` : 'Colony (2 í leik: 8, 3-4 í leik: 12)'
+  return `${colonyLabel} & Platinum (12)`
+}
+
 function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard, playerCount) {
   const lines = []
   lines.push('Ríkið:')
@@ -86,9 +92,7 @@ function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCa
   }
   if (colonyPlatinum && colonyCard && platinumCard) {
     lines.push('')
-    const colonyCount = playerCount >= 2 ? (playerCount === 2 ? 8 : 12) : null
-    const colonyLabel = colonyCount != null ? `Colony (${colonyCount})` : 'Colony (2 í leik: 8, 3-4 í leik: 12)'
-    lines.push(`Velmegun: ${colonyLabel} & Platinum (12)`)
+    lines.push(`Velmegun: ${formatColonyPlatinumLabel(playerCount)}`)
   }
   return lines.join('\n')
 }
@@ -556,7 +560,7 @@ export default function Suggester() {
             className="gen-btn"
             style={{ background: copied ? 'var(--green, #3fb950)' : 'var(--bg3)', color: copied ? '#fff' : 'var(--text)' }}
             onClick={() => {
-              const text = buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard, selectedPlayers.length)
+              const text = buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard, showAdvanced ? selectedPlayers.length : 0)
               navigator.clipboard.writeText(text).then(() => {
                 setCopied(true)
                 setTimeout(() => setCopied(false), 2000)
@@ -619,9 +623,7 @@ export default function Suggester() {
           {colonyPlatinum && colonyCard && platinumCard && (
             <div style={{ marginTop: '1.5rem' }}>
               <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: '.75rem' }}>
-                {selectedPlayers.length >= 2
-                  ? `Velmegun — Colony (${selectedPlayers.length === 2 ? 8 : 12}) & Platinum (12)`
-                  : 'Velmegun — Colony (2 í leik: 8, 3-4 í leik: 12) & Platinum (12)'}
+                Velmegun — {formatColonyPlatinumLabel(showAdvanced ? selectedPlayers.length : 0)}
               </div>
               <div className="kingdom-display">
                 {[colonyCard, platinumCard].map(card => (

--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -70,7 +70,7 @@ function formatCost(card) {
   return `${card.cost}`
 }
 
-function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard) {
+function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard, playerCount) {
   const lines = []
   lines.push('Ríkið:')
   for (const c of [...kingdom].sort((a, b) => (a.cost ?? 0) - (b.cost ?? 0))) {
@@ -86,7 +86,9 @@ function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCa
   }
   if (colonyPlatinum && colonyCard && platinumCard) {
     lines.push('')
-    lines.push('Velmegun: Colony & Platinum')
+    const colonyCount = playerCount >= 2 ? (playerCount === 2 ? 8 : 12) : null
+    const colonyLabel = colonyCount != null ? `Colony (${colonyCount})` : 'Colony (2 í leik: 8, 3-4 í leik: 12)'
+    lines.push(`Velmegun: ${colonyLabel} & Platinum (12)`)
   }
   return lines.join('\n')
 }
@@ -554,7 +556,7 @@ export default function Suggester() {
             className="gen-btn"
             style={{ background: copied ? 'var(--green, #3fb950)' : 'var(--bg3)', color: copied ? '#fff' : 'var(--text)' }}
             onClick={() => {
-              const text = buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard)
+              const text = buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard, selectedPlayers.length)
               navigator.clipboard.writeText(text).then(() => {
                 setCopied(true)
                 setTimeout(() => setCopied(false), 2000)
@@ -617,7 +619,9 @@ export default function Suggester() {
           {colonyPlatinum && colonyCard && platinumCard && (
             <div style={{ marginTop: '1.5rem' }}>
               <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: '.75rem' }}>
-                Velmegun — Colony &amp; Platinum
+                {selectedPlayers.length >= 2
+                  ? `Velmegun — Colony (${selectedPlayers.length === 2 ? 8 : 12}) & Platinum (12)`
+                  : 'Velmegun — Colony (2 í leik: 8, 3-4 í leik: 12) & Platinum (12)'}
               </div>
               <div className="kingdom-display">
                 {[colonyCard, platinumCard].map(card => (


### PR DESCRIPTION
## Summary
- Colony count: 8 for 2 players, 12 for 3-4 players
- Platinum: always 12
- Shows exact count when players are selected in advanced mode, otherwise shows both options
- Export text also includes counts

## Test plan
- [x] Generate with Prosperity cards — verify Colony/Platinum shows counts
- [x] With 2 players selected — verify "Colony (8) & Platinum (12)"
- [x] With 3+ players — verify "Colony (12) & Platinum (12)"
- [x] Without players — verify shows both options
- [x] Copy export text — verify counts included

Closes #8