### PR TITLE
feat: include landscape cards in suggestions by Dominion setup rules

### DIFF
--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -17,6 +17,56 @@ const TYPE_COLOR = {
   Way: '#a78bfa', Ally: '#f43f5e', Trait: '#06b6d4', Prophecy: '#e879f9',
 }
 
+// Subtypes not exposed in the card data. Liaisons summon an Ally; Omens summon a Prophecy.
+const LIAISON_NAMES = new Set([
+  'Bauble', 'Sycophant', 'Importer', 'Underling', 'Broker', 'Contract',
+  'Emissary', 'Galleria', 'Guildmaster', 'Wizards', 'Hunter', 'Modify',
+  'Specialist', 'Swap',
+])
+const OMEN_NAMES = new Set([
+  'Aristocrat', 'Artist', 'Daimyo', 'Gold mine', 'Imperial envoy',
+  'Mountain shrine', 'Snake witch', 'Tanuki',
+])
+
+function pickRandom(arr, n) {
+  if (arr.length === 0 || n <= 0) return []
+  return [...arr].sort(() => Math.random() - 0.5).slice(0, Math.min(n, arr.length))
+}
+
+function pickLandscapeCards(extrasPool, kingdom) {
+  const byType = { Event: [], Landmark: [], Project: [], Way: [], Trait: [], Ally: [], Prophecy: [] }
+  for (const c of extrasPool) {
+    if (byType[c.card_type]) byType[c.card_type].push(c)
+  }
+
+  const picked = []
+
+  // Always include 1 Way (kingdom-wide modifier from Menagerie) if any are available
+  picked.push(...pickRandom(byType.Way, 1))
+
+  // Always include 1 Trait (attaches to a Kingdom pile, from Plunder) if any are available
+  picked.push(...pickRandom(byType.Trait, 1))
+
+  // 1 Ally only if the kingdom contains a Liaison (Allies expansion rule)
+  if (kingdom.some(c => LIAISON_NAMES.has(c.name))) {
+    picked.push(...pickRandom(byType.Ally, 1))
+  }
+
+  // 1 Prophecy only if the kingdom contains an Omen (Rising Sun rule)
+  if (kingdom.some(c => OMEN_NAMES.has(c.name))) {
+    picked.push(...pickRandom(byType.Prophecy, 1))
+  }
+
+  // 1–2 from Event/Landmark/Project combined (Dominion's standard 0–2 cap, biased toward inclusion)
+  const elp = [...byType.Event, ...byType.Landmark, ...byType.Project]
+  if (elp.length > 0) {
+    const count = Math.random() < 0.5 ? 1 : 2
+    picked.push(...pickRandom(elp, count))
+  }
+
+  return picked
+}
+
 const PLAYER_MODES = [
   { id: 'unseen',    name: 'Óspilað',    desc: 'Spil sem valdir hafa aldrei séð' },
   { id: 'rare',      name: 'Sjaldséð',   desc: 'Spil sem valdir hafa sjaldnast spilað' },
@@ -343,13 +393,9 @@ export default function Suggester() {
       newKingdom = [...candidates].sort(() => Math.random() - 0.5).slice(0, 10)
     }
 
-    // 0, 1, or 2 extras (equal 1/3 chance each)
-    let newExtras = []
-    if (extrasPool.length > 0) {
-      const roll = Math.random()
-      const count = roll < 1/3 ? 0 : roll < 2/3 ? 1 : 2
-      newExtras = [...extrasPool].sort(() => Math.random() - 0.5).slice(0, count)
-    }
+    // Landscape cards: pick by Dominion setup rules (Way/Trait/Event/Landmark/Project always
+    // when available; Ally and Prophecy only when triggered by a Liaison or Omen in the kingdom).
+    const newExtras = pickLandscapeCards(extrasPool, newKingdom)
 
     // Colony + Platinum: 10% chance per Prosperity kingdom card
     const prosperityCount = newKingdom.filter(c => c.expansion === 'Prosperity').length


### PR DESCRIPTION
Closes #16.

## Summary
- Always include applicable landscape cards in kingdom suggestions instead of randomly omitting them ~33% of the time.
- Apply Dominion's actual setup rules so each landscape type appears only when it's relevant.

## Behavior
| Type | Rule |
|------|------|
| Way | 1 if any are in the selected expansions |
| Trait | 1 if any are in the selected expansions |
| Ally | 1 only if the rolled kingdom contains a Liaison (Allies) |
| Prophecy | 1 only if the rolled kingdom contains an Omen (Rising Sun) |
| Event / Landmark / Project | 1–2 combined when any are available |

## Notes
- The card data does not tag Liaisons or Omens — both subtypes are hardcoded sets at the top of `Suggester.jsx`. The Liaison list covers all 14 Allies cards. The Omen list covers the 8 Rising Sun Omens that exist in this dataset (Aristocrat, Artist, Daimyo, Gold mine, Imperial envoy, Mountain shrine, Snake witch, Tanuki). If new Rising Sun / Omens are added to the data later, the set will need updating.
- UI plumbing for landscape cards already existed (`ExtraCard`, "Aukaleg" section in the export text), so no rendering changes were needed.

## Test plan
- [ ] Pick **Allies** only → suggest several kingdoms; confirm an Ally appears iff the kingdom contains a Liaison and never otherwise.
- [ ] Pick **Rising Sun** only → confirm a Prophecy appears iff the kingdom contains an Omen.
- [ ] Pick **Menagerie** → confirm exactly 1 Way appears every time.
- [ ] Pick **Plunder** → confirm exactly 1 Trait appears every time.
- [ ] Pick **Empires + Adventures + Renaissance** → confirm 1–2 Events/Landmarks/Projects appear every time.
- [ ] Pick a mix (Allies + Rising Sun + Menagerie) → confirm rules stack correctly.
- [ ] No expansion selected (all available) → confirm landscape cards are present and rules still hold.