### PR TITLE
Handle ties on FunFacts cards + longest-gap fact

### DIFF
--- a/src/tabs/FunFacts.jsx
+++ b/src/tabs/FunFacts.jsx
@@ -104,11 +104,16 @@ export default function FunFacts({ onGameNav }) {
     // ── Cards ────────────────────────────────────────────────────────────────
     const kingdomCards = cards.filter(c => !c.removed && !c.isSupplyCard)
 
-    const topCard = kingdomCards.length
-      ? [...kingdomCards].sort((a, b) => b.times_used - a.times_used)[0]
-      : null
+    const maxUsage = kingdomCards.length
+      ? Math.max(...kingdomCards.map(c => c.times_used))
+      : 0
+    const topCards = maxUsage > 0
+      ? kingdomCards.filter(c => c.times_used === maxUsage)
+      : []
 
-    const leastUsed = kingdomCards.filter(c => c.times_used > 0).sort((a, b) => a.times_used - b.times_used)[0] || null
+    const usedCards = kingdomCards.filter(c => c.times_used > 0)
+    const minUsage = usedCards.length ? Math.min(...usedCards.map(c => c.times_used)) : 0
+    const leastUsedCards = minUsage > 0 ? usedCards.filter(c => c.times_used === minUsage) : []
     const neverUsed = kingdomCards.filter(c => c.times_used === 0)
 
     // Card power couple (most co-appearing pair in kingdoms)
@@ -122,10 +127,12 @@ export default function FunFacts({ onGameNav }) {
         }
       }
     })
-    const topPairEntry = Object.entries(pairCounts).sort((a, b) => b[1] - a[1])[0]
-    const topPair = topPairEntry
-      ? { cards: topPairEntry[0].split('|||'), count: topPairEntry[1] }
-      : null
+    const maxPairCount = Math.max(0, ...Object.values(pairCounts))
+    const topPairs = maxPairCount > 0
+      ? Object.entries(pairCounts)
+          .filter(([, count]) => count === maxPairCount)
+          .map(([key]) => ({ cards: key.split('|||') }))
+      : []
 
     // ── Players ───────────────────────────────────────────────────────────────
     const sortedBySecond = [...players].sort((a, b) => b.second - a.second)
@@ -172,6 +179,23 @@ export default function FunFacts({ onGameNav }) {
     const streakNote = topStreakOwner?.name === CLUB_OWNER && topStreak !== topStreakOwner
       ? ` (${CLUB_OWNER}: ${topStreakOwner.streak} í röð)`
       : ''
+
+    // Longest wait between a player's appearances
+    let longestGap = null
+    const sortedGames = [...games].sort((a, b) => a.game_num - b.game_num)
+    const lastSeenGameNum = {}
+    for (const g of sortedGames) {
+      for (const name of (g.players || [])) {
+        const prev = lastSeenGameNum[name]
+        if (prev != null) {
+          const gap = g.game_num - prev
+          if (!longestGap || gap > longestGap.gap) {
+            longestGap = { name, gap, fromGame: prev, toGame: g.game_num }
+          }
+        }
+        lastSeenGameNum[name] = g.game_num
+      }
+    }
 
     // Never won (min 5 games, 0 wins)
     const neverWon = players.filter(p => p.games >= 5 && p.first === 0).sort((a, b) => b.games - a.games)
@@ -333,6 +357,12 @@ export default function FunFacts({ onGameNav }) {
         value: `${topStreak.streak} í röð`,
         desc: `${topStreak.name} fór á óstöðvanlegt skrið — ${topStreak.streak} sigurleikar í röð${streakNote}`,
       },
+      longestGap && {
+        icon: '⏳', title: 'Lengsta bið milli spila',
+        value: `${longestGap.gap} leikir`,
+        desc: `${longestGap.name} mætti aftur eftir ${longestGap.gap} leiki (leikur #${longestGap.fromGame} → #${longestGap.toGame})`,
+        gameNums: [longestGap.toGame],
+      },
       runnerUp && {
         icon: '🥈', title: 'Smiður á 2. sæti',
         value: `${runnerUp.second}× í 2. sæti`,
@@ -355,20 +385,28 @@ export default function FunFacts({ onGameNav }) {
       },
 
       // Spil
-      topCard && {
+      topCards.length > 0 && {
         icon: '♣', title: 'Uppáhaldskortin',
-        value: topCard.name,
-        desc: `Kom fyrir í ${topCard.times_used} ríkjum — uppáhald klúbbsins`,
+        value: topCards.length === 1 ? topCards[0].name : `${topCards.length} spil jafnt`,
+        desc: topCards.length === 1
+          ? `Kom fyrir í ${maxUsage} ríkjum — uppáhald klúbbsins`
+          : `${topCards.slice(0, 3).map(c => c.name).join(', ')}${topCards.length > 3 ? ` … og ${topCards.length - 3} til viðbótar` : ''} — hvert kom fyrir í ${maxUsage} ríkjum`,
       },
-      topPair && {
+      topPairs.length > 0 && {
         icon: '🔗', title: 'Kraftapar',
-        value: `${topPair.cards[0]} + ${topPair.cards[1]}`,
-        desc: `Þessi tvö spil hafa verið í sama ríki ${topPair.count} sinnum — skapaðar fyrir hvort annað`,
+        value: topPairs.length === 1
+          ? `${topPairs[0].cards[0]} + ${topPairs[0].cards[1]}`
+          : `${topPairs.length} pör jafnt`,
+        desc: topPairs.length === 1
+          ? `Þessi tvö spil hafa verið í sama ríki ${maxPairCount} sinnum — skapaðar fyrir hvort annað`
+          : `${topPairs.slice(0, 2).map(p => `${p.cards[0]} + ${p.cards[1]}`).join(', ')}${topPairs.length > 2 ? ` … og ${topPairs.length - 2} til viðbótar` : ''} — hvert par hefur verið saman í ${maxPairCount} ríkjum`,
       },
-      leastUsed && {
-        icon: '🦗', title: 'Gleymda kortið',
-        value: leastUsed.name,
-        desc: `Kom aðeins fyrir ${leastUsed.times_used} sinni${leastUsed.times_used !== 1 ? 'um' : ''} — greinilega ekki vinsælt`,
+      leastUsedCards.length > 0 && {
+        icon: '🦗', title: 'Gleymdu spilin',
+        value: leastUsedCards.length === 1 ? leastUsedCards[0].name : `${leastUsedCards.length} spil jafnt`,
+        desc: leastUsedCards.length === 1
+          ? `Kom aðeins fyrir ${minUsage} sinni${minUsage !== 1 ? 'um' : ''} — greinilega ekki vinsælt`
+          : `${leastUsedCards.slice(0, 3).map(c => c.name).join(', ')}${leastUsedCards.length > 3 ? ` … og ${leastUsedCards.length - 3} til viðbótar` : ''} — hvert spilað aðeins ${minUsage} sinni${minUsage !== 1 ? 'um' : ''}`,
       },
       neverUsed.length > 0 && {
         icon: '👻', title: 'Ósnert spil',

--- a/src/tabs/FunFacts.jsx
+++ b/src/tabs/FunFacts.jsx
@@ -364,12 +364,12 @@ export default function FunFacts({ onGameNav }) {
         gameNums: [longestGap.toGame],
       },
       runnerUp && {
-        icon: '🥈', title: 'Smiður á 2. sæti',
+        icon: '🥈', title: 'Eilíft silfur',
         value: `${runnerUp.second}× í 2. sæti`,
         desc: `${runnerUp.name} hefur lokið í 2. sæti fleiri sinnum en nokkuð annað. Svo nálægt, svo oft — silfursætisgengni!${runnerUpNote}`,
       },
       lastPlaceKing && {
-        icon: '🎯', title: 'Hinn góðgjarna taparinn',
+        icon: '🎯', title: 'Eilíft botnsæti',
         value: `${lastPlaceKing[1]} síðustu sæti`,
         desc: `${lastPlaceKing[0]} hefur gjöfult lagt ${lastPlaceKing[1]} síðustu sæti til tölfræðinnar. Sérhver klúbbur þarf einhver til að halda egóinu í skefjum.${lastPlaceNote}`,
       },


### PR DESCRIPTION
Closes #24.

## Summary

Four small changes in `src/tabs/FunFacts.jsx`:

- **Uppáhaldskortin** — generalized from a single `[0]` pick to all cards tied at max usage. Today only Gardens hits the max (11) so the singular branch fires; future ties are handled.
- **Gleymdu spilin** (was *Gleymda kortið*, retitled to plural) — generalized to all cards at the minimum non-zero usage. Real impact: 151 cards are tied at 1 use in the current dataset; the fact now reads "151 spil jafnt" + sample of 3.
- **Kraftapar** — generalized to all pairs tied at max co-occurrence. Today King's Court + Smithy alone holds the record at 5; future ties are handled.
- **NEW: ⏳ Lengsta bið milli spila** — surfaces the longest gap between any player's consecutive appearances. Currently fires for *Mosi mætti aftur eftir 83 leiki (leikur #35 → #118)*. Includes a clickable game-number button via the existing `gameNums`/`onGameNav` pipe.

Multi-result rendering follows the existing `Ósnert spil` pattern: count in the `value`, first 2-3 names + `… og N til viðbótar` in `desc`.

## Test plan

- [ ] Visit `#funfacts`. *Uppáhaldskortin* still shows Gardens. *Gleymdu spilin* now shows "151 spil jafnt" with 3 sample names. *Kraftapar* still shows King's Court + Smithy. *Lengsta bið* shows Mosi 83 leikir with a clickable `#118` button.
- [ ] Click the `#118` button on the longest-gap fact → History tab opens that game's modal.