### PR TITLE
Show cost + 'Aldrei spilað' on random card boxes

### DIFF
--- a/src/components/RandomCardBox.jsx
+++ b/src/components/RandomCardBox.jsx
@@ -4,6 +4,12 @@ import CardImage from './CardImage'
 
 const EXTRA_FIELDS = ['events', 'landmarks', 'projects', 'ways', 'allies', 'traits', 'prophecy']
 
+// Landscape (wide) card types — render their image bigger to stay readable.
+const LANDSCAPE_TYPES = new Set(['Event', 'Landmark', 'Project', 'Way', 'Ally', 'Trait', 'Prophecy'])
+
+// Card types you don't pay for (landmarks, ways, allies, traits, prophecies are free).
+const COSTLESS_TYPES = new Set(['Landmark', 'Way', 'Ally', 'Trait', 'Prophecy'])
+
 const LABELS = {
   played: 'Handahófskennt spil',
   unplayed: 'Óspilað spil',
@@ -46,7 +52,9 @@ export default function RandomCardBox({ pool, onCardClick, onGameClick }) {
     ? `${card.times_used}× spiluð (${games.length > 0 ? Math.round(card.times_used / games.length * 100) : 0}%)`
     : null
 
-  const hasCost = card.cost != null || card.debt != null || card.potion
+  const isLandscape = LANDSCAPE_TYPES.has(card.card_type)
+  const imgWidth = isLandscape ? 130 : 60
+  const hasCost = !COSTLESS_TYPES.has(card.card_type) && (card.cost != null || card.debt != null || card.potion)
   const renderCost = () => {
     if (card.debt) return <span className="coin debt">{card.debt}D</span>
     if (card.potion) return <><span className="coin">{card.cost ?? 0}</span><span className="coin potion">S</span></>
@@ -65,7 +73,7 @@ export default function RandomCardBox({ pool, onCardClick, onGameClick }) {
 
       <div style={{ display: 'flex', gap: '.85rem', alignItems: 'flex-start' }}>
         <div
-          style={{ flexShrink: 0, width: 60, borderRadius: 6, overflow: 'hidden', background: 'var(--bg3)', border: '1px solid var(--border)', cursor: 'pointer' }}
+          style={{ flexShrink: 0, width: imgWidth, borderRadius: 6, overflow: 'hidden', background: 'var(--bg3)', border: '1px solid var(--border)', cursor: 'pointer' }}
           onClick={() => onCardClick?.(card)}
         >
           <CardImage name={card.name} style={{ width: '100%', display: 'block' }} />

--- a/src/components/RandomCardBox.jsx
+++ b/src/components/RandomCardBox.jsx
@@ -46,6 +46,13 @@ export default function RandomCardBox({ pool, onCardClick, onGameClick }) {
     ? `${card.times_used}× spiluð (${games.length > 0 ? Math.round(card.times_used / games.length * 100) : 0}%)`
     : null
 
+  const hasCost = card.cost != null || card.debt != null || card.potion
+  const renderCost = () => {
+    if (card.debt) return <span className="coin debt">{card.debt}D</span>
+    if (card.potion) return <><span className="coin">{card.cost ?? 0}</span><span className="coin potion">S</span></>
+    return <span className="coin">{card.cost}</span>
+  }
+
   const cardTextSnippet = card.card_text
     ? (card.card_text.length > 150 ? card.card_text.slice(0, 150) + '…' : card.card_text)
     : null
@@ -76,9 +83,11 @@ export default function RandomCardBox({ pool, onCardClick, onGameClick }) {
               </span>
             )}
           </div>
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.3rem .8rem', marginTop: '.2rem' }}>
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '.3rem .8rem', marginTop: '.2rem', alignItems: 'center' }}>
             <span style={{ fontSize: '.75rem', color: 'var(--dim)' }}>{card.expansion}</span>
+            {hasCost && <span style={{ display: 'inline-flex', alignItems: 'center', gap: '.2rem' }}>{renderCost()}</span>}
             {usageText && <span style={{ fontSize: '.75rem', color: 'var(--dim)' }}>{usageText}</span>}
+            {pool === 'unplayed' && <span style={{ fontSize: '.75rem', color: 'var(--dim)', fontStyle: 'italic' }}>Aldrei spilað</span>}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Tiny UX fill-in for the two random-card boxes on the Dashboard.

## Summary

- **Cost coin** rendered in the metadata row of both played and unplayed boxes (debt and potion variants supported, reusing the \`coin\` / \`coin.debt\` / \`coin.potion\` CSS classes already used in \`CardModal\`).
- **\`Aldrei spilað\`** italic tag added to the unplayed box's metadata row so it's no longer visually emptier than the played box.

Net diff: +10 / -1 in \`src/components/RandomCardBox.jsx\`.

## Test plan

- [ ] Played random card on Dashboard shows: expansion · cost coin · "N× spiluð (X%)"
- [ ] Unplayed random card on Dashboard shows: expansion · cost coin · "Aldrei spilað"
- [ ] Cost coin renders correctly for $-cost cards (Smithy 4), debt cards (Engineer / Capital), and potion cards (Familiar / Vineyard)