### PR TITLE
Skip split-pile members in random card boxes

### DIFF
--- a/src/components/RandomCardBox.jsx
+++ b/src/components/RandomCardBox.jsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import DATA from '../data'
 import CardImage from './CardImage'
+import { SPLIT_PILE_MEMBERS } from '../constants'
 
 const EXTRA_FIELDS = ['events', 'landmarks', 'projects', 'ways', 'allies', 'traits', 'prophecy']
 
@@ -20,8 +21,8 @@ export default function RandomCardBox({ pool, onCardClick, onGameClick }) {
 
   const { card, recentGames } = useMemo(() => {
     const filter = pool === 'unplayed'
-      ? c => !c.isSupplyCard && !c.removed && c.times_used === 0
-      : c => !c.isSupplyCard && !c.removed && c.times_used > 0
+      ? c => !c.isSupplyCard && !c.removed && c.times_used === 0 && !SPLIT_PILE_MEMBERS.has(c.name)
+      : c => !c.isSupplyCard && !c.removed && c.times_used > 0 && !SPLIT_PILE_MEMBERS.has(c.name)
     const candidates = cards.filter(filter)
     if (candidates.length === 0) return { card: null, recentGames: [] }
     const card = candidates[Math.floor(Math.random() * candidates.length)]

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,6 +29,26 @@ export const PALETTE = {
   blue: '#58a6ff',
 }
 
+// Split-pile member cards. Kingdoms reference the parent pile name
+// (e.g., "Augurs"), so members like "Herb Gatherer" never appear in
+// any kingdom and have no card image of their own. Anything that picks
+// random kingdom cards should skip these.
+export const SPLIT_PILE_MEMBERS = new Set([
+  // Knights (Dark Ages)
+  'Sir Bailey', 'Sir Destry', 'Sir Martin', 'Sir Michael', 'Sir Vander',
+  'Dame Anna', 'Dame Josephine', 'Dame Molly', 'Dame Natalie', 'Dame Sylvia',
+  // Castles (Empires)
+  'Humble Castle', 'Crumbling Castle', 'Small Castle', 'Haunted Castle',
+  'Opulent Castle', 'Sprawling Castle', 'Grand Castle', "King's Castle",
+  // Allies split piles
+  'Herb Gatherer', 'Acolyte', 'Sorceress', 'Lich',                 // Augurs
+  'Battle Plan', 'Archer', 'Warlord', 'Territory',                  // Clashes
+  'Tent', 'Garrison', 'Hill Fort', 'Stronghold',                    // Forts
+  'Old Map', 'Voyage', 'Sunken Treasure', 'Distant Shore',          // Odysseys
+  'Town Crier', 'Blacksmith', 'Miller', 'Elder',                    // Townsfolk
+  'Student', 'Conjurer', 'Sorcerer',                                // Wizards (Lich shared with Augurs above)
+])
+
 export const TABS = [
   { id: 'dashboard',   label: '📊 Yfirlit' },
   { id: 'players',     label: '🏆 Leikmenn' },


### PR DESCRIPTION
Fix: Herb Gatherer (and ~30 other split-pile member cards) were eligible for the random card boxes on the Dashboard, even though they have no card image of their own — the image silently failed.

## Why

Kingdoms in the data reference the parent pile name (e.g. \`Augurs\`), not the individual members (\`Herb Gatherer\`, \`Acolyte\`, \`Sorceress\`, \`Lich\`). The member cards exist as separate entries in the cards table but have \`times_used: 0\` and no uploaded image, so they fell into the unplayed pool with broken images.

## Fix

\`src/constants.js\` — new \`SPLIT_PILE_MEMBERS\` Set covering all known split-pile members in the game:
- Knights (Dark Ages): 10 cards
- Castles (Empires): 8 cards
- Allies split piles (Augurs, Clashes, Forts, Odysseys, Townsfolk, Wizards): 24 cards

\`RandomCardBox.jsx\` — filter both played and unplayed pools to exclude these.

## Test plan

- [ ] Refresh the dashboard repeatedly; the random unplayed box should never show Herb Gatherer, Acolyte, Town Crier, Old Map, etc. — only "real" never-played kingdom cards.
- [ ] No regressions on cards that are full kingdom piles in their own right (Augurs, Knights, Castles parent piles still eligible).