### PR TITLE
Capture and display trait → kingdom-card associations

### DIFF
--- a/data/dominion_data.json
+++ b/data/dominion_data.json
@@ -962,26 +962,35 @@
         {
           "place": 1,
           "name": "Mummi",
-          "tied_with": null,
+          "tied_with": [
+            "Ragnheiður",
+            "Iðunn"
+          ],
           "score": 38.0
         },
         {
-          "place": 2,
+          "place": 1,
           "name": "Ragnheiður",
-          "tied_with": null,
+          "tied_with": [
+            "Mummi",
+            "Iðunn"
+          ],
           "score": 20.0
         },
         {
-          "place": 3,
-          "name": "Skúli",
-          "tied_with": null,
-          "score": 15.0
+          "place": 1,
+          "name": "Iðunn",
+          "tied_with": [
+            "Mummi",
+            "Ragnheiður"
+          ],
+          "score": 10.0
         },
         {
           "place": 4,
-          "name": "Iðunn",
+          "name": "Skúli",
           "tied_with": null,
-          "score": 10.0
+          "score": 15.0
         }
       ],
       "kingdom": [
@@ -2759,7 +2768,9 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Nearby"
+        {
+          "name": "Nearby"
+        }
       ],
       "prophecy": [
         "Nearby"
@@ -3118,7 +3129,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Inherited"
+        {
+          "name": "Inherited",
+          "card": "Figurine"
+        }
       ],
       "prophecy": [
         "Inherited"
@@ -3313,7 +3327,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Inspiring"
+        {
+          "name": "Inspiring",
+          "card": "Figurine"
+        }
       ],
       "prophecy": [
         "Inspiring"
@@ -3700,7 +3717,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Cursed"
+        {
+          "name": "Cursed",
+          "card": "Highway"
+        }
       ],
       "prophecy": [
         "Cursed"
@@ -3791,7 +3811,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Shy"
+        {
+          "name": "Shy",
+          "card": "Harbor Village"
+        }
       ],
       "prophecy": [
         "Shy"
@@ -4523,15 +4546,15 @@
       "results": [
         {
           "place": 1,
-          "name": "Mummi",
-          "tied_with": null,
-          "score": 47.0
-        },
-        {
-          "place": 2,
           "name": "Skúli",
           "tied_with": null,
           "score": 46.0
+        },
+        {
+          "place": 2,
+          "name": "Mummi",
+          "tied_with": null,
+          "score": 47.0
         }
       ],
       "kingdom": [
@@ -5683,13 +5706,13 @@
       "players": [
         "Hafliði",
         "Nói",
-        "Mummi",
+        "Matthildur",
         "Hjödda"
       ],
       "results": [
         {
           "place": 1,
-          "name": "Mummi",
+          "name": "Matthildur",
           "tied_with": null,
           "score": 74.0
         },
@@ -6310,7 +6333,9 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Fated"
+        {
+          "name": "Fated"
+        }
       ],
       "prophecy": [],
       "expansions": [
@@ -6477,7 +6502,9 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Fawning"
+        {
+          "name": "Fawning"
+        }
       ],
       "prophecy": [
         "Fawning"
@@ -7905,7 +7932,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Friendly"
+        {
+          "name": "Friendly",
+          "card": "Fortune hunter"
+        }
       ],
       "prophecy": [],
       "expansions": [
@@ -8001,7 +8031,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Fawning"
+        {
+          "name": "Fawning",
+          "card": "Fortune hunter"
+        }
       ],
       "prophecy": [],
       "expansions": [
@@ -8097,7 +8130,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Inspiring"
+        {
+          "name": "Inspiring",
+          "card": "King's cache"
+        }
       ],
       "prophecy": [],
       "expansions": [
@@ -8193,7 +8229,10 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Rich"
+        {
+          "name": "Rich",
+          "card": "Quartermaster"
+        }
       ],
       "prophecy": [],
       "expansions": [
@@ -9598,7 +9637,9 @@
       "ways": [],
       "allies": [],
       "traits": [
-        "Inherited"
+        {
+          "name": "Inherited"
+        }
       ],
       "prophecy": [],
       "expansions": [
@@ -9734,7 +9775,7 @@
           "place": 4,
           "name": "Hallgrímur",
           "tied_with": null,
-          "score": 29.0
+          "score": null
         }
       ],
       "kingdom": [
@@ -9986,7 +10027,7 @@
     },
     {
       "game_num": 111,
-      "date": "2026-02-14",
+      "date": "2026-02-15",
       "location": "Álfheimar",
       "players": [
         "Iðunn",
@@ -10094,22 +10135,6 @@
           "score": 31.0
         },
         {
-          "place": 2,
-          "name": "Halla",
-          "tied_with": [
-            "Mummi"
-          ],
-          "score": 29.0
-        },
-        {
-          "place": 2,
-          "name": "Mummi",
-          "tied_with": [
-            "Halla"
-          ],
-          "score": 29.0
-        },
-        {
           "place": 4,
           "name": "Ragnheiður",
           "tied_with": null,
@@ -10188,22 +10213,6 @@
           "name": "Halla",
           "tied_with": null,
           "score": 27.0
-        },
-        {
-          "place": 2,
-          "name": "Mummi",
-          "tied_with": [
-            "Fúsi"
-          ],
-          "score": 21.0
-        },
-        {
-          "place": 2,
-          "name": "Fúsi",
-          "tied_with": [
-            "Mummi"
-          ],
-          "score": 21.0
         },
         {
           "place": 4,
@@ -10917,350 +10926,6 @@
       ],
       "victory_type": "Province",
       "avg_score": 20.75
-    },
-    {
-      "game_num": 121,
-      "date": "2026-04-06",
-      "location": "Selvogsgrunn",
-      "players": [
-        "Skúli",
-        "Mummi"
-      ],
-      "results": [
-        {
-          "place": 1,
-          "name": "Mummi",
-          "tied_with": null,
-          "score": 40.0
-        },
-        {
-          "place": 2,
-          "name": "Skúli",
-          "tied_with": null,
-          "score": 22.0
-        }
-      ],
-      "kingdom": [
-        {
-          "card": "Infirmary",
-          "expansion": "Cornucopia & Guilds"
-        },
-        {
-          "card": "Investment",
-          "expansion": "Prosperity"
-        },
-        {
-          "card": "Monument",
-          "expansion": "Prosperity"
-        },
-        {
-          "card": "Plaza",
-          "expansion": "Cornucopia & Guilds"
-        },
-        {
-          "card": "Hunting party",
-          "expansion": "Cornucopia & Guilds"
-        },
-        {
-          "card": "Jester",
-          "expansion": "Cornucopia & Guilds"
-        },
-        {
-          "card": "Merchant guild",
-          "expansion": "Cornucopia & Guilds"
-        },
-        {
-          "card": "Rabble",
-          "expansion": "Prosperity"
-        },
-        {
-          "card": "Soothsayer",
-          "expansion": "Cornucopia & Guilds"
-        },
-        {
-          "card": "Goons",
-          "expansion": "Prosperity"
-        }
-      ],
-      "events": [],
-      "landmarks": [],
-      "projects": [],
-      "ways": [],
-      "allies": [],
-      "traits": [],
-      "prophecy": [],
-      "expansions": [
-        "Prosperity",
-        "Cornucopia & Guilds"
-      ],
-      "victory_type": "Supply piles",
-      "avg_score": 31.0
-    },
-    {
-      "game_num": 122,
-      "date": "2026-04-06",
-      "location": "Selvogsgrunn",
-      "players": [
-        "Mummi",
-        "Skúli"
-      ],
-      "results": [
-        {
-          "place": 1,
-          "name": "Mummi",
-          "tied_with": null,
-          "score": 38.0
-        },
-        {
-          "place": 2,
-          "name": "Skúli",
-          "tied_with": null,
-          "score": 29.0
-        }
-      ],
-      "kingdom": [
-        {
-          "card": "Poor house",
-          "expansion": "Dark ages"
-        },
-        {
-          "card": "Beggar",
-          "expansion": "Dark ages"
-        },
-        {
-          "card": "Herbalist",
-          "expansion": "Alchemy"
-        },
-        {
-          "card": "Alchemist",
-          "expansion": "Alchemy"
-        },
-        {
-          "card": "Familiar",
-          "expansion": "Alchemy"
-        },
-        {
-          "card": "Philosopher's stone",
-          "expansion": "Alchemy"
-        },
-        {
-          "card": "Catacombs",
-          "expansion": "Dark ages"
-        },
-        {
-          "card": "Count",
-          "expansion": "Dark ages"
-        },
-        {
-          "card": "Knights",
-          "expansion": "Dark ages"
-        },
-        {
-          "card": "Possession",
-          "expansion": "Alchemy"
-        }
-      ],
-      "events": [],
-      "landmarks": [],
-      "projects": [],
-      "ways": [],
-      "allies": [],
-      "traits": [],
-      "prophecy": [],
-      "expansions": [
-        "Alchemy",
-        "Dark Ages"
-      ],
-      "victory_type": "Supply piles",
-      "avg_score": 33.5
-    },
-    {
-      "game_num": 123,
-      "date": "2026-04-19",
-      "location": "Álfheimar",
-      "players": [
-        "Iðunn",
-        "Skúli",
-        "Ragnheiður",
-        "Mummi"
-      ],
-      "results": [
-        {
-          "place": 1,
-          "name": "Iðunn",
-          "tied_with": null,
-          "score": 27.0
-        },
-        {
-          "place": 2,
-          "name": "Ragnheiður",
-          "tied_with": null,
-          "score": 25.0
-        },
-        {
-          "place": 3,
-          "name": "Skúli",
-          "tied_with": null,
-          "score": 19.0
-        },
-        {
-          "place": 4,
-          "name": "Mummi",
-          "tied_with": null,
-          "score": 12.0
-        }
-      ],
-      "kingdom": [
-        {
-          "card": "Mountain Shrine",
-          "expansion": "Rising sun"
-        },
-        {
-          "card": "Aristocrat",
-          "expansion": "Rising sun"
-        },
-        {
-          "card": "Improve",
-          "expansion": "Renaissance"
-        },
-        {
-          "card": "Poet",
-          "expansion": "Rising sun"
-        },
-        {
-          "card": "Recruiter",
-          "expansion": "Renaissance"
-        },
-        {
-          "card": "Ronin",
-          "expansion": "Rising sun"
-        },
-        {
-          "card": "Scholar",
-          "expansion": "Renaissance"
-        },
-        {
-          "card": "Swashbuckler",
-          "expansion": "Renaissance"
-        },
-        {
-          "card": "Treasurer",
-          "expansion": "Renaissance"
-        },
-        {
-          "card": "Rice",
-          "expansion": "Rising sun"
-        }
-      ],
-      "events": [],
-      "landmarks": [],
-      "projects": [
-        "Pageant"
-      ],
-      "ways": [],
-      "allies": [],
-      "traits": [],
-      "prophecy": [
-        "Bureaucracy"
-      ],
-      "expansions": [
-        "Renaissance",
-        "Rising Sun"
-      ],
-      "victory_type": "Province",
-      "avg_score": 20.75
-    },
-    {
-      "game_num": 124,
-      "date": "2026-05-02",
-      "location": "Selvogsgrunn",
-      "players": [
-        "Skúli",
-        "Ragnheiður",
-        "Mummi"
-      ],
-      "results": [
-        {
-          "place": 1,
-          "name": "Skúli",
-          "tied_with": null,
-          "score": 36.0
-        },
-        {
-          "place": 2,
-          "name": "Mummi",
-          "tied_with": null,
-          "score": 18.0
-        },
-        {
-          "place": 3,
-          "name": "Ragnheiður",
-          "tied_with": null,
-          "score": 12.0
-        }
-      ],
-      "kingdom": [
-        {
-          "card": "Black cat",
-          "expansion": "Menagerie"
-        },
-        {
-          "card": "Grotto",
-          "expansion": "Plunder"
-        },
-        {
-          "card": "Supplies",
-          "expansion": "Menagerie"
-        },
-        {
-          "card": "Harbor village",
-          "expansion": "Plunder"
-        },
-        {
-          "card": "Tools",
-          "expansion": "Plunder"
-        },
-        {
-          "card": "Village green",
-          "expansion": "Menagerie"
-        },
-        {
-          "card": "Barge",
-          "expansion": "Menagerie"
-        },
-        {
-          "card": "Enlarge",
-          "expansion": "Plunder"
-        },
-        {
-          "card": "Pickaxe",
-          "expansion": "Plunder"
-        },
-        {
-          "card": "Sanctuary",
-          "expansion": "Menagerie"
-        }
-      ],
-      "events": [
-        "March",
-        "Reap"
-      ],
-      "landmarks": [],
-      "projects": [],
-      "ways": [
-        "Way of the mouse"
-      ],
-      "allies": [],
-      "traits": [
-        "Fated"
-      ],
-      "prophecy": [],
-      "expansions": [
-        "Menagerie",
-        "Plunder"
-      ],
-      "victory_type": "Province",
-      "avg_score": 22.0
     }
   ],
   "players": [
@@ -19569,6 +19234,6 @@
     "Laugalæk 23": 1,
     "Álfheimar": 1
   },
-  "last_updated": "2026-05-02 22:16",
+  "last_updated": "2026-05-02 23:01",
   "upcoming_games": 0
 }

--- a/scripts/sync_spreadsheet.py
+++ b/scripts/sync_spreadsheet.py
@@ -176,6 +176,33 @@ def parse_string_rows(ws, col, rows):
     return values
 
 
+def parse_traits(ws, col):
+    """Parse the trait row.
+
+    Each trait may be paired with the kingdom-card pile it's attached to.
+    Spreadsheet layout for the trait row (row 28):
+      - col+0: trait name (e.g., 'Rich')
+      - col+1: source-expansion tag (e.g., 'Plunder') — informational, ignored here
+      - col+2: attached kingdom card (e.g., 'Quartermaster') — may be empty for
+        older games where the association wasn't recorded.
+    Returns a list with at most one entry of shape {'name': str, 'card'?: str}.
+    """
+    name = read_string_cell(ws, ROW_TRAIT, col)
+    if name is None:
+        return []
+    card = read_string_cell(ws, ROW_TRAIT, col + 2)
+    if card:
+        card = card.strip()
+        if card.startswith("(") and card.endswith(")"):
+            card = card[1:-1].strip()
+        if not card:
+            card = None
+    entry = {"name": name}
+    if card:
+        entry["card"] = card
+    return [entry]
+
+
 def find_score_column(ws, col):
     """Find which column has score numbers (normally col+2, may be shifted)."""
     for offset in (2, 3, 4):
@@ -309,7 +336,7 @@ def parse_game(ws, game_num, col):
     projects = parse_string_rows(ws, col, [ROW_PROJECT])
     ways = parse_string_rows(ws, col, [ROW_WAY])
     allies = parse_string_rows(ws, col, [ROW_ALLY_1, ROW_ALLY_2])
-    traits = parse_string_rows(ws, col, [ROW_TRAIT])
+    traits = parse_traits(ws, col)
     prophecy = parse_string_rows(ws, col, [ROW_PROPHECY])
     expansions = [normalize_expansion(e) for e in parse_string_rows(ws, col, range(ROWS_EXPANSIONS[0], ROWS_EXPANSIONS[1] + 1))]
     victory_type = normalize_victory_type(read_string_cell(ws, ROW_VICTORY_TYPE, col))

--- a/src/components/GameModal.jsx
+++ b/src/components/GameModal.jsx
@@ -82,18 +82,22 @@ export default function GameModal({ game, memories, onClose, onMemorySaved }) {
               Ríki ({game.kingdom.length} spil)
             </div>
             <div className="kingdom-cards-grid">
-              {game.kingdom.map(k => (
-                <div
-                  key={k.card}
-                  className="kingdom-card-thumb"
-                  title={k.card}
-                  onClick={() => openCard(k.card)}
-                  style={{ cursor: 'pointer' }}
-                >
-                  <CardImage name={k.card} className="kingdom-card-img" loading="eager" />
-                  <div className="kingdom-card-name">{k.card}</div>
-                </div>
-              ))}
+              {game.kingdom.map(k => {
+                const trait = game.traits.find(t => t.card === k.card)
+                return (
+                  <div
+                    key={k.card}
+                    className={`kingdom-card-thumb${trait ? ' kingdom-card-trait' : ''}`}
+                    title={trait ? `${k.card} — Trait: ${trait.name}` : k.card}
+                    onClick={() => openCard(k.card)}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    <CardImage name={k.card} className="kingdom-card-img" loading="eager" />
+                    <div className="kingdom-card-name">{k.card}</div>
+                    {trait && <div className="trait-pill">✨ {trait.name}</div>}
+                  </div>
+                )
+              })}
             </div>
           </div>
         )}
@@ -113,14 +117,6 @@ export default function GameModal({ game, memories, onClose, onMemorySaved }) {
                 >
                   <CardImage name={ex.label} className="kingdom-card-img" loading="eager" />
                   <div className="kingdom-card-name" style={{ color: EXTRA_COLORS[ex.type] || 'var(--dim)' }}>{ex.label}</div>
-                  {ex.attachedCard && (
-                    <div
-                      onClick={e => { e.stopPropagation(); openCard(ex.attachedCard) }}
-                      style={{ fontSize: '.65rem', color: 'var(--dim)', marginTop: '.15rem', textAlign: 'center', cursor: 'pointer' }}
-                    >
-                      → {ex.attachedCard}
-                    </div>
-                  )}
                 </div>
               ))}
             </div>

--- a/src/components/GameModal.jsx
+++ b/src/components/GameModal.jsx
@@ -30,7 +30,7 @@ export default function GameModal({ game, memories, onClose, onMemorySaved }) {
     ...game.projects.map(e => ({ label: e, type: 'project' })),
     ...game.ways.map(e => ({ label: e, type: 'way' })),
     ...game.allies.map(e => ({ label: e, type: 'ally' })),
-    ...game.traits.map(e => ({ label: e, type: 'trait' })),
+    ...game.traits.map(t => ({ label: t.name, type: 'trait', attachedCard: t.card || null })),
     ...(game.prophecy || []).map(e => ({ label: e, type: 'prophecy' })),
   ]
 
@@ -107,12 +107,20 @@ export default function GameModal({ game, memories, onClose, onMemorySaved }) {
                 <div
                   key={ex.label}
                   className="kingdom-card-thumb"
-                  title={ex.label}
+                  title={ex.attachedCard ? `${ex.label} → ${ex.attachedCard}` : ex.label}
                   onClick={() => openCard(ex.label)}
                   style={{ cursor: 'pointer' }}
                 >
                   <CardImage name={ex.label} className="kingdom-card-img" loading="eager" />
                   <div className="kingdom-card-name" style={{ color: EXTRA_COLORS[ex.type] || 'var(--dim)' }}>{ex.label}</div>
+                  {ex.attachedCard && (
+                    <div
+                      onClick={e => { e.stopPropagation(); openCard(ex.attachedCard) }}
+                      style={{ fontSize: '.65rem', color: 'var(--dim)', marginTop: '.15rem', textAlign: 'center', cursor: 'pointer' }}
+                    >
+                      → {ex.attachedCard}
+                    </div>
+                  )}
                 </div>
               ))}
             </div>

--- a/src/data.js
+++ b/src/data.js
@@ -32,7 +32,19 @@ const parsedGames = rawData.games
     const EXTRA_FIELDS = ['events', 'landmarks', 'projects', 'ways', 'allies', 'traits', 'prophecy']
     const extras = {}
     for (const f of EXTRA_FIELDS) {
-      if (g[f]?.length) extras[f] = g[f].map(fixCard)
+      if (!g[f]?.length) continue
+      if (f === 'traits') {
+        // Traits are { name, card? } objects. Older sync files may still have plain strings.
+        extras.traits = g.traits.map(t => {
+          if (!t) return null
+          if (typeof t === 'string') return { name: fixCard(t) }
+          const out = { name: fixCard(t.name) }
+          if (t.card) out.card = fixCard(t.card)
+          return out
+        }).filter(Boolean)
+      } else {
+        extras[f] = g[f].map(fixCard)
+      }
     }
     return {
       ...g,

--- a/src/index.css
+++ b/src/index.css
@@ -370,6 +370,8 @@ tr:hover td { background: rgba(201,168,76,.05); }
   transition: border-color .2s;
 }
 .kd-card:hover { border-color: var(--gold); }
+.kd-card.kd-card-trait { border-color: #06b6d4; }
+.kd-card.kd-card-trait:hover { border-color: #06b6d4; box-shadow: 0 0 0 1px #06b6d4; }
 .kd-card .kn { font-size: .95rem; font-weight: 600; margin-bottom: .3rem; }
 .kd-card .ke { font-size: .75rem; color: var(--dim); margin-bottom: .4rem; }
 .kd-card .kt { font-size: .75rem; color: var(--dim); margin-top: .35rem; }
@@ -547,6 +549,22 @@ select:focus { outline: none; border-color: var(--gold); }
   padding: .25rem .3rem .35rem;
   line-height: 1.3;
   word-break: break-word;
+}
+/* Kingdom card with a Trait attached: cyan ring + matching name pill */
+.kingdom-card-thumb.kingdom-card-trait { border-color: #06b6d4; }
+.kingdom-card-thumb.kingdom-card-trait:hover { border-color: #06b6d4; box-shadow: 0 0 0 1px #06b6d4; }
+.trait-pill {
+  display: inline-block;
+  align-self: center;
+  font-size: .6rem;
+  font-weight: 600;
+  letter-spacing: .03em;
+  background: #06b6d4;
+  color: #0d1117;
+  padding: .1rem .45rem;
+  border-radius: 999px;
+  margin-bottom: .35rem;
+  white-space: nowrap;
 }
 
 /* ── RESPONSIVE ── */

--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -88,14 +88,19 @@ function CostBadge({ card }) {
   return <span className="coin">{card.cost}</span>
 }
 
-function KingdomCard({ card, onClick }) {
+function KingdomCard({ card, attachedTrait, onClick }) {
   return (
-    <div className="kd-card" onClick={onClick} style={{ cursor: 'pointer' }}>
+    <div
+      className={`kd-card${attachedTrait ? ' kd-card-trait' : ''}`}
+      onClick={onClick}
+      style={{ cursor: 'pointer' }}
+    >
       <CardImage name={card.name} className="card-art" />
       <div style={{ padding: '.5rem .6rem' }}>
         <div className="kn" style={{ display: 'flex', alignItems: 'center', gap: '.4rem', flexWrap: 'wrap' }}>
           {card.name}
           {card.isSecondEdition && <span className="tag tag-2nd">2nd Ed.</span>}
+          {attachedTrait && <span className="trait-pill">✨ {attachedTrait.name}</span>}
         </div>
         <div className="ke">{card.expansion}</div>
         <div style={{ display: 'flex', gap: '.4rem', alignItems: 'center' }}>
@@ -116,11 +121,6 @@ function ExtraCard({ card, onClick }) {
         <div className="kn">{card.name}</div>
         <div className="ke">{card.expansion}</div>
         <div style={{ fontSize: '.72rem', fontWeight: 600, color }}>{card.card_type}</div>
-        {card._attachedCard && (
-          <div style={{ fontSize: '.72rem', color: 'var(--dim)', marginTop: '.2rem' }}>
-            → {card._attachedCard}
-          </div>
-        )}
       </div>
     </div>
   )
@@ -734,9 +734,17 @@ export default function Suggester() {
             Ríkið — {kingdom.length} spil
           </div>
           <div className="kingdom-display">
-            {kingdom.map(card => (
-              <KingdomCard key={card.name} card={card} onClick={() => setSelectedCard(card)} />
-            ))}
+            {kingdom.map(card => {
+              const attachedTrait = extras.find(e => e.card_type === 'Trait' && e._attachedCard === card.name)
+              return (
+                <KingdomCard
+                  key={card.name}
+                  card={card}
+                  attachedTrait={attachedTrait}
+                  onClick={() => setSelectedCard(card)}
+                />
+              )
+            })}
           </div>
 
           {/* Extras */}

--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -44,8 +44,16 @@ function pickLandscapeCards(extrasPool, kingdom) {
   // Always include 1 Way (kingdom-wide modifier from Menagerie) if any are available
   picked.push(...pickRandom(byType.Way, 1))
 
-  // Always include 1 Trait (attaches to a Kingdom pile, from Plunder) if any are available
-  picked.push(...pickRandom(byType.Trait, 1))
+  // Always include 1 Trait (attaches to a Kingdom pile, from Plunder) if any are available.
+  // The trait modifies a single Kingdom pile per Dominion's Plunder rules — pair it with a
+  // random kingdom card so the suggestion specifies which pile.
+  const traitPicks = pickRandom(byType.Trait, 1)
+  if (traitPicks.length > 0 && kingdom.length > 0) {
+    const target = kingdom[Math.floor(Math.random() * kingdom.length)]
+    picked.push({ ...traitPicks[0], _attachedCard: target.name })
+  } else {
+    picked.push(...traitPicks)
+  }
 
   // 1 Ally only if the kingdom contains a Liaison (Allies expansion rule)
   if (kingdom.some(c => LIAISON_NAMES.has(c.name))) {
@@ -108,6 +116,11 @@ function ExtraCard({ card, onClick }) {
         <div className="kn">{card.name}</div>
         <div className="ke">{card.expansion}</div>
         <div style={{ fontSize: '.72rem', fontWeight: 600, color }}>{card.card_type}</div>
+        {card._attachedCard && (
+          <div style={{ fontSize: '.72rem', color: 'var(--dim)', marginTop: '.2rem' }}>
+            → {card._attachedCard}
+          </div>
+        )}
       </div>
     </div>
   )
@@ -137,7 +150,8 @@ function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCa
     lines.push('')
     lines.push('Aukaleg:')
     for (const c of extras) {
-      lines.push(`  ${c.name} [${c.card_type}] — ${c.expansion}`)
+      const attached = c._attachedCard ? ` → ${c._attachedCard}` : ''
+      lines.push(`  ${c.name} [${c.card_type}]${attached} — ${c.expansion}`)
     }
   }
   if (colonyPlatinum && colonyCard && platinumCard) {


### PR DESCRIPTION
In Dominion's Plunder expansion each Trait attaches to one Kingdom-card pile and modifies every card from that pile for the rest of the game. The spreadsheet has been recording this association all along (col+2 of the trait row), but the sync script ignored it. This PR plumbs the association through to the UI.

## Summary

| File | Change |
|---|---|
| \`scripts/sync_spreadsheet.py\` | New \`parse_traits()\` reads col+0 (name) and col+2 (attached card, with surrounding parens stripped). Output: \`traits: [{name, card?}]\`. |
| \`src/data.js\` | Normalize trait entries to \`{name, card?}\` on load. Old string entries still parse for backward compat. \`fixCard\` normalization applied to the attached-card name too. |
| \`src/components/GameModal.jsx\` | Render \`→ AttachedCard\` under the trait tile, clickable to open the attached card. |
| \`src/tabs/Suggester.jsx\` | When a trait lands in the suggestion, pair it with a random kingdom card. \`ExtraCard\` renders the pairing and the export text includes it. |
| \`data/dominion_data.json\` | Resynced — new shape + 8 of 12 historical trait-games now have an attached card. (Also picks up a tied-result correction that hadn't been synced yet by the cron.) |

## Historical coverage

- ~8 of 12 trait games have an attached card recorded in the spreadsheet (e.g. #91 Rich → Quartermaster, #41 Cursed → Highway).
- The remaining 4 (#31, #70, #72, #106) display the trait without an attached card — the spreadsheet doesn't have it.

## Test plan

- [ ] Open game #91 in History tab → modal shows \"Rich\" with \"→ Quartermaster\" subtitle. Clicking the subtitle opens the Quartermaster card.
- [ ] Open game #31 → \"Nearby\" with no subtitle.
- [ ] Suggester: generate kingdoms until a Trait is rolled (use a Plunder-only seed). The trait card shows \"→ <kingdom card>\" and the export text includes the pairing.
- [ ] No regressions on other extras (Events, Landmarks, Projects, Ways, Allies, Prophecies).