### PR TITLE
Detect and display Dominion side piles, heirlooms, and named targets

### DIFF
--- a/src/components/CardImage.jsx
+++ b/src/components/CardImage.jsx
@@ -4,7 +4,17 @@ import { cardImgUrl } from '../constants'
 export default function CardImage({ name, className = '', style = {}, loading = 'lazy' }) {
   const [failed, setFailed] = useState(false)
 
-  if (failed) return null
+  if (failed) {
+    return (
+      <div
+        className={`card-image-fallback ${className}`}
+        style={style}
+        title={`Engin mynd: ${name}`}
+      >
+        <span className="card-image-fallback-name">{name}</span>
+      </div>
+    )
+  }
 
   return (
     <img

--- a/src/components/GameModal.jsx
+++ b/src/components/GameModal.jsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useMemo } from 'react'
 import CardImage from './CardImage'
 import CardModal from './CardModal'
 import MemorySection from './MemorySection'
 import MemoryEditor from './MemoryEditor'
 import DATA from '../data'
+import { detectSidePiles, detectHeirlooms } from '../lib/sidePiles'
 
 const EXTRA_COLORS = { event: '#f97316', landmark: '#3fb950', project: '#58a6ff', way: '#a78bfa', ally: '#f43f5e', trait: '#06b6d4', prophecy: '#e879f9' }
 
@@ -33,6 +34,27 @@ export default function GameModal({ game, memories, onClose, onMemorySaved }) {
     ...game.traits.map(t => ({ label: t.name, type: 'trait', attachedCard: t.card || null })),
     ...(game.prophecy || []).map(e => ({ label: e, type: 'prophecy' })),
   ]
+
+  // Side pieces implied by the kingdom (Loots, Spoils, Boons, Heirlooms, ...).
+  // Resolve each kingdom name to its full card object so card_text is available
+  // for regex detection (Loot, Spoils, Ruins, Imps, Spirits, Wishes).
+  const { sidePiles, heirlooms } = useMemo(() => {
+    const cardByName = new Map(DATA.cards.map(c => [c.name, c]))
+    const kingdomCards = game.kingdom.map(k => cardByName.get(k.card)).filter(Boolean)
+    const extraCards = [
+      ...game.events,
+      ...game.landmarks,
+      ...game.projects,
+      ...game.ways,
+      ...game.allies,
+      ...game.traits.map(t => t.name),
+      ...(game.prophecy || []),
+    ].map(n => cardByName.get(n)).filter(Boolean)
+    return {
+      sidePiles: detectSidePiles(kingdomCards, extraCards),
+      heirlooms: detectHeirlooms(kingdomCards),
+    }
+  }, [game])
 
   const victoryBadgeClass = {
     Province: 'badge-province',
@@ -84,17 +106,21 @@ export default function GameModal({ game, memories, onClose, onMemorySaved }) {
             <div className="kingdom-cards-grid">
               {game.kingdom.map(k => {
                 const trait = game.traits.find(t => t.card === k.card)
+                const heirloom = heirlooms.find(h => h.kingdomCard === k.card)?.heirloom
+                const cls = trait ? 'kingdom-card-trait' : heirloom ? 'kingdom-card-heirloom' : ''
+                const title = trait ? `${k.card} — Trait: ${trait.name}` : heirloom ? `${k.card} — Heirloom: ${heirloom}` : k.card
                 return (
                   <div
                     key={k.card}
-                    className={`kingdom-card-thumb${trait ? ' kingdom-card-trait' : ''}`}
-                    title={trait ? `${k.card} — Trait: ${trait.name}` : k.card}
+                    className={`kingdom-card-thumb${cls ? ' ' + cls : ''}`}
+                    title={title}
                     onClick={() => openCard(k.card)}
                     style={{ cursor: 'pointer' }}
                   >
                     <CardImage name={k.card} className="kingdom-card-img" loading="eager" />
                     <div className="kingdom-card-name">{k.card}</div>
                     {trait && <div className="trait-pill">✨ {trait.name}</div>}
+                    {heirloom && !trait && <div className="heirloom-pill">🎁 {heirloom}</div>}
                   </div>
                 )
               })}
@@ -118,6 +144,21 @@ export default function GameModal({ game, memories, onClose, onMemorySaved }) {
                   <CardImage name={ex.label} className="kingdom-card-img" loading="eager" />
                   <div className="kingdom-card-name" style={{ color: EXTRA_COLORS[ex.type] || 'var(--dim)' }}>{ex.label}</div>
                 </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Side piles implied by kingdom (Loots, Spoils, Boons, Hexes, ...) */}
+        {sidePiles.length > 0 && (
+          <div style={{ marginTop: '1rem' }}>
+            <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: '.5rem' }}>Aukabunkar ({sidePiles.length})</div>
+            <div style={{ display: 'flex', gap: '.4rem', flexWrap: 'wrap' }}>
+              {sidePiles.map(p => (
+                <span key={p.pile} className="side-pile-chip">
+                  <span className="side-pile-icon">{p.icon}</span>
+                  {p.pile}
+                </span>
               ))}
             </div>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -566,6 +566,41 @@ select:focus { outline: none; border-color: var(--gold); }
   margin-bottom: .35rem;
   white-space: nowrap;
 }
+/* Heirloom pill (gold) and Bane pill (red), same shape as trait-pill */
+.heirloom-pill, .bane-pill {
+  display: inline-block;
+  align-self: center;
+  font-size: .6rem;
+  font-weight: 600;
+  letter-spacing: .03em;
+  padding: .1rem .45rem;
+  border-radius: 999px;
+  margin-bottom: .35rem;
+  white-space: nowrap;
+  color: #0d1117;
+}
+.heirloom-pill { background: #f0cb6c; }
+.bane-pill { background: #f43f5e; color: #fff; }
+.kingdom-card-thumb.kingdom-card-heirloom { border-color: #f0cb6c; }
+.kingdom-card-thumb.kingdom-card-heirloom:hover { border-color: #f0cb6c; box-shadow: 0 0 0 1px #f0cb6c; }
+.kd-card.kd-card-heirloom { border-color: #f0cb6c; }
+.kd-card.kd-card-heirloom:hover { border-color: #f0cb6c; box-shadow: 0 0 0 1px #f0cb6c; }
+.kd-card.kd-card-bane { border-color: #f43f5e; }
+.kd-card.kd-card-bane:hover { border-color: #f43f5e; box-shadow: 0 0 0 1px #f43f5e; }
+/* Side-pile chips (text + icon, no card image) */
+.side-pile-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: .35rem;
+  font-size: .78rem;
+  font-weight: 600;
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: .3rem .7rem;
+  color: var(--text);
+}
+.side-pile-icon { font-size: 1rem; line-height: 1; }
 
 /* ── RESPONSIVE ── */
 @media (max-width: 768px) {

--- a/src/index.css
+++ b/src/index.css
@@ -587,6 +587,26 @@ select:focus { outline: none; border-color: var(--gold); }
 .kd-card.kd-card-heirloom:hover { border-color: #f0cb6c; box-shadow: 0 0 0 1px #f0cb6c; }
 .kd-card.kd-card-bane { border-color: #f43f5e; }
 .kd-card.kd-card-bane:hover { border-color: #f43f5e; box-shadow: 0 0 0 1px #f43f5e; }
+/* Fallback when a card image fails to load (typo, homebrew, missing upload) */
+.card-image-fallback {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background: var(--bg3);
+  border: 1px dashed var(--border);
+  color: var(--dim);
+  aspect-ratio: 5 / 7;
+  width: 100%;
+  padding: .4rem .3rem;
+  box-sizing: border-box;
+}
+.card-image-fallback-name {
+  font-size: .65rem;
+  font-weight: 600;
+  line-height: 1.2;
+  word-break: break-word;
+}
 /* Side-pile chips (text + icon, no card image) */
 .side-pile-chip {
   display: inline-flex;

--- a/src/lib/sidePiles.js
+++ b/src/lib/sidePiles.js
@@ -1,0 +1,154 @@
+// Detect which Dominion "side pieces" should be set up alongside the
+// chosen kingdom + extras. There are three kinds:
+//
+// 1. Side piles — non-Supply piles shared across triggering cards
+//    (Loots, Spoils, Ruins, Imps, Spirits, Wishes, Madman, Mercenary,
+//    Prizes, Travelers, Zombies, Bat, Black Market deck, Boons, Hexes).
+//
+// 2. Heirlooms — Treasure cards added to a player's starting deck when
+//    a specific Nocturne kingdom card is in play.
+//
+// 3. Named targets — a specific card chosen from the supply for cards
+//    like Way of the Mouse, Riverboat, and Young Witch's Bane.
+
+// ── Side piles ─────────────────────────────────────────────────────────────
+
+// Regex on card_text. Each entry is { pile, regex, icon }.
+// The regex is matched against the card_text of every kingdom + extras card.
+const REGEX_TRIGGERS = [
+  { pile: 'Loots',   regex: /\bgain.{0,30}\bLoot\b/i,    icon: '🪙' },
+  { pile: 'Spoils',  regex: /\bgain.{0,30}\bSpoils\b/i,  icon: '💰' },
+  { pile: 'Ruins',   regex: /\bgain.{0,30}\bRuins?\b/i,  icon: '🏚️' },
+  { pile: 'Imps',    regex: /\bgain.{0,30}\bImp\b/i,     icon: '👹' },
+  { pile: 'Spirits', regex: /\bgain.{0,30}\bSpirit/i,    icon: '👻' },
+  { pile: 'Wishes',  regex: /\bgain.{0,30}\bWish\b/i,    icon: '💫' },
+]
+
+// Specific kingdom card name → side pile(s) and icon.
+const NAME_TRIGGERS = {
+  'Hermit':       [{ pile: 'Madman',             icon: '🤪' }],
+  'Urchin':       [{ pile: 'Mercenary',          icon: '💸' }],
+  'Tournament':   [{ pile: 'Prizes',             icon: '🏆' }],
+  'Page':         [{ pile: 'Travelers (Page)',   icon: '🛤️' }],
+  'Peasant':      [{ pile: 'Travelers (Peasant)', icon: '🛤️' }],
+  'Necromancer':  [{ pile: 'Zombies',            icon: '🧟' }],
+  'Vampire':      [{ pile: 'Bat',                icon: '🦇' }],
+  'Black Market': [{ pile: 'Black Market deck',  icon: '🃏' }],
+}
+
+// Type categories that trigger a deck once any qualifying card is in the kingdom.
+const FATE_CARDS = new Set([
+  'Druid', 'Bard', 'Pixie', 'Pooka', 'Sacred Grove', 'Skulk', 'Tracker', 'Idol',
+])
+const DOOM_CARDS = new Set([
+  'Cursed Village', 'Familiar', 'Idol', 'Leprechaun', 'Skulk',
+  'Tormentor', 'Vampire', 'Werewolf', "Devil's Workshop",
+])
+
+// ── Heirlooms ─────────────────────────────────────────────────────────────
+
+const HEIRLOOMS = {
+  'Cemetery':    'Haunted Mirror',
+  'Fool':        'Lucky Coin',
+  'Pixie':       'Goat',
+  'Pooka':       'Cursed Gold',
+  'Secret Cave': 'Magic Lamp',
+  'Shepherd':    'Pasture',
+  'Tracker':     'Pouch',
+}
+
+// ── Named targets ─────────────────────────────────────────────────────────
+
+// Card name → predicate building a candidate pool of kingdom cards from outside
+// the current kingdom. Returns null when no eligible candidate exists.
+const NAMED_TARGETS = {
+  'Way of the Mouse': {
+    label: 'Mús-spil',
+    icon: '🐭',
+    pool: c => [2, 3].includes(c.cost) && !c.isAttack,
+  },
+  'Riverboat': {
+    label: 'Bátsmaður-spil',
+    icon: '🚣',
+    pool: c => c.cost === 5 && !c.isAttack,
+  },
+  'Young Witch': {
+    label: 'Bane',
+    icon: '🧙',
+    pool: c => c.cost === 3,
+  },
+}
+
+// ── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Detect side piles triggered by a kingdom + extras combination.
+ * Returns an array of { pile, icon } in stable order.
+ */
+export function detectSidePiles(kingdom = [], extras = []) {
+  const found = new Map() // pile → { pile, icon } (preserves insertion order)
+  const all = [...kingdom, ...extras]
+
+  for (const { pile, regex, icon } of REGEX_TRIGGERS) {
+    if (all.some(c => c.card_text && regex.test(c.card_text))) {
+      found.set(pile, { pile, icon })
+    }
+  }
+  for (const c of all) {
+    const triggers = NAME_TRIGGERS[c.name]
+    if (!triggers) continue
+    for (const t of triggers) found.set(t.pile, t)
+  }
+  if (kingdom.some(c => FATE_CARDS.has(c.name))) {
+    found.set('Boons', { pile: 'Boons', icon: '🌟' })
+  }
+  if (kingdom.some(c => DOOM_CARDS.has(c.name))) {
+    found.set('Hexes', { pile: 'Hexes', icon: '🔮' })
+  }
+  return [...found.values()]
+}
+
+/**
+ * Detect heirlooms triggered by the kingdom.
+ * Returns an array of { kingdomCard, heirloom }.
+ */
+export function detectHeirlooms(kingdom = []) {
+  return kingdom
+    .filter(c => HEIRLOOMS[c.name])
+    .map(c => ({ kingdomCard: c.name, heirloom: HEIRLOOMS[c.name] }))
+}
+
+/**
+ * Pick named-target cards (Way of the Mouse target, Riverboat target,
+ * Young Witch bane). Looks at every card in `kingdom + extras` and, for
+ * each that has a named-target rule, picks a random eligible card from
+ * `allCards` that is not already in `kingdom`.
+ *
+ * Returns an array of { source, target, label, icon }.
+ *   - source: the trigger card (e.g., the Way of the Mouse card object)
+ *   - target: the picked card object
+ */
+export function pickNamedTargets(kingdom = [], extras = [], allCards = []) {
+  const inKingdom = new Set(kingdom.map(c => c.name))
+  const out = []
+  for (const c of [...kingdom, ...extras]) {
+    const rule = NAMED_TARGETS[c.name]
+    if (!rule) continue
+    const pool = allCards.filter(x =>
+      x.card_type === 'Kingdom' &&
+      !x.isSupplyCard &&
+      !x.removed &&
+      !inKingdom.has(x.name) &&
+      x.name !== c.name &&
+      rule.pool(x)
+    )
+    if (pool.length === 0) continue
+    const target = pool[Math.floor(Math.random() * pool.length)]
+    out.push({ source: c, target, label: rule.label, icon: rule.icon })
+    // Reserve the target so two named targets don't collide.
+    inKingdom.add(target.name)
+  }
+  return out
+}
+
+export const __test_internals = { REGEX_TRIGGERS, NAME_TRIGGERS, FATE_CARDS, DOOM_CARDS, HEIRLOOMS, NAMED_TARGETS }

--- a/src/lib/sidePiles.js
+++ b/src/lib/sidePiles.js
@@ -1,3 +1,5 @@
+import { SPLIT_PILE_MEMBERS } from '../constants'
+
 // Detect which Dominion "side pieces" should be set up alongside the
 // chosen kingdom + extras. There are three kinds:
 //
@@ -138,6 +140,7 @@ export function pickNamedTargets(kingdom = [], extras = [], allCards = []) {
       x.card_type === 'Kingdom' &&
       !x.isSupplyCard &&
       !x.removed &&
+      !SPLIT_PILE_MEMBERS.has(x.name) &&
       !inKingdom.has(x.name) &&
       x.name !== c.name &&
       rule.pool(x)

--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -1,4 +1,5 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
+import { detectSidePiles, detectHeirlooms, pickNamedTargets } from '../lib/sidePiles'
 import CardImage from '../components/CardImage'
 import CardModal from '../components/CardModal'
 import DATA from '../data'
@@ -88,10 +89,14 @@ function CostBadge({ card }) {
   return <span className="coin">{card.cost}</span>
 }
 
-function KingdomCard({ card, attachedTrait, onClick }) {
+function KingdomCard({ card, attachedTrait, attachedHeirloom, baneOf, onClick }) {
+  const highlight = attachedTrait ? 'kd-card-trait'
+    : baneOf ? 'kd-card-bane'
+    : attachedHeirloom ? 'kd-card-heirloom'
+    : ''
   return (
     <div
-      className={`kd-card${attachedTrait ? ' kd-card-trait' : ''}`}
+      className={`kd-card${highlight ? ' ' + highlight : ''}`}
       onClick={onClick}
       style={{ cursor: 'pointer' }}
     >
@@ -101,6 +106,8 @@ function KingdomCard({ card, attachedTrait, onClick }) {
           {card.name}
           {card.isSecondEdition && <span className="tag tag-2nd">2nd Ed.</span>}
           {attachedTrait && <span className="trait-pill">✨ {attachedTrait.name}</span>}
+          {attachedHeirloom && <span className="heirloom-pill">🎁 {attachedHeirloom}</span>}
+          {baneOf && <span className="bane-pill">🧙 Bane</span>}
         </div>
         <div className="ke">{card.expansion}</div>
         <div style={{ display: 'flex', gap: '.4rem', alignItems: 'center' }}>
@@ -139,7 +146,7 @@ function formatColonyPlatinumLabel(playerCount) {
   return `${colonyLabel} & Platinum (12)`
 }
 
-function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard, playerCount) {
+function buildExportText(kingdom, extras, sidePiles, heirlooms, namedTargets, colonyPlatinum, colonyCard, platinumCard, playerCount) {
   const lines = []
   lines.push('Ríkið:')
   for (const c of [...kingdom].sort((a, b) => (a.cost ?? 0) - (b.cost ?? 0))) {
@@ -153,6 +160,21 @@ function buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCa
       const attached = c._attachedCard ? ` → ${c._attachedCard}` : ''
       lines.push(`  ${c.name} [${c.card_type}]${attached} — ${c.expansion}`)
     }
+  }
+  if (sidePiles.length > 0) {
+    lines.push('')
+    lines.push('Aukabunkar:')
+    for (const p of sidePiles) lines.push(`  ${p.icon} ${p.pile}`)
+  }
+  if (heirlooms.length > 0) {
+    lines.push('')
+    lines.push('Heirlooms:')
+    for (const h of heirlooms) lines.push(`  ${h.heirloom} (frá ${h.kingdomCard})`)
+  }
+  if (namedTargets.length > 0) {
+    lines.push('')
+    lines.push('Auka kort:')
+    for (const nt of namedTargets) lines.push(`  ${nt.label} fyrir ${nt.source.name}: ${nt.target.name}`)
   }
   if (colonyPlatinum && colonyCard && platinumCard) {
     lines.push('')
@@ -198,6 +220,9 @@ export default function Suggester() {
   const [customRatios, setCustomRatios] = useState({})
   const [kingdom, setKingdom] = useState([])
   const [extras, setExtras] = useState([])
+  const [sidePiles, setSidePiles] = useState([])
+  const [heirlooms, setHeirlooms] = useState([])
+  const [namedTargets, setNamedTargets] = useState([])
   const [colonyPlatinum, setColonyPlatinum] = useState(false)
   const showPotions = useMemo(
     () => [...kingdom, ...extras].some(c => c.potion),
@@ -417,8 +442,17 @@ export default function Suggester() {
 
     const hasCurseGiver = [...newKingdom, ...newExtras].some(c => c.isCurseGiver)
 
+    // Side pieces — piles, heirlooms, and named targets that Dominion's setup
+    // rules call for given the chosen kingdom + extras.
+    const newSidePiles = detectSidePiles(newKingdom, newExtras)
+    const newHeirlooms = detectHeirlooms(newKingdom)
+    const newNamedTargets = pickNamedTargets(newKingdom, newExtras, cards)
+
     setKingdom(newKingdom)
     setExtras(newExtras)
+    setSidePiles(newSidePiles)
+    setHeirlooms(newHeirlooms)
+    setNamedTargets(newNamedTargets)
     setColonyPlatinum(newColony)
     setShowCurses(hasCurseGiver)
     setCopied(false)
@@ -685,7 +719,7 @@ export default function Suggester() {
             className="gen-btn"
             style={{ background: copied ? 'var(--green, #3fb950)' : 'var(--bg3)', color: copied ? '#fff' : 'var(--text)' }}
             onClick={() => {
-              const text = buildExportText(kingdom, extras, colonyPlatinum, colonyCard, platinumCard, showAdvanced ? selectedPlayers.length : 0)
+              const text = buildExportText(kingdom, extras, sidePiles, heirlooms, namedTargets, colonyPlatinum, colonyCard, platinumCard, showAdvanced ? selectedPlayers.length : 0)
               navigator.clipboard.writeText(text).then(() => {
                 setCopied(true)
                 setTimeout(() => setCopied(false), 2000)
@@ -736,11 +770,13 @@ export default function Suggester() {
           <div className="kingdom-display">
             {kingdom.map(card => {
               const attachedTrait = extras.find(e => e.card_type === 'Trait' && e._attachedCard === card.name)
+              const heirloom = heirlooms.find(h => h.kingdomCard === card.name)?.heirloom
               return (
                 <KingdomCard
                   key={card.name}
                   card={card}
                   attachedTrait={attachedTrait}
+                  attachedHeirloom={heirloom}
                   onClick={() => setSelectedCard(card)}
                 />
               )
@@ -756,6 +792,49 @@ export default function Suggester() {
               <div className="kingdom-display">
                 {extras.map(card => (
                   <ExtraCard key={card.name} card={card} onClick={() => setSelectedCard(card)} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Side piles (Loots, Spoils, Ruins, Boons, Hexes, etc.) */}
+          {sidePiles.length > 0 && (
+            <div style={{ marginTop: '1.5rem' }}>
+              <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: '.75rem' }}>
+                Aukabunkar — {sidePiles.length}
+              </div>
+              <div style={{ display: 'flex', gap: '.5rem', flexWrap: 'wrap' }}>
+                {sidePiles.map(p => (
+                  <span key={p.pile} className="side-pile-chip">
+                    <span className="side-pile-icon">{p.icon}</span>
+                    {p.pile}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Named targets — referenced cards from outside the kingdom (Mouse, Riverboat, Bane) */}
+          {namedTargets.length > 0 && (
+            <div style={{ marginTop: '1.5rem' }}>
+              <div style={{ fontSize: '.75rem', color: 'var(--dim)', textTransform: 'uppercase', letterSpacing: '.08em', marginBottom: '.75rem' }}>
+                Auka kort — {namedTargets.length}
+              </div>
+              <div className="kingdom-display">
+                {namedTargets.map(nt => (
+                  <KingdomCard
+                    key={`${nt.source.name}->${nt.target.name}`}
+                    card={nt.target}
+                    baneOf={nt.source.name === 'Young Witch' ? nt.source.name : null}
+                    onClick={() => setSelectedCard(nt.target)}
+                  />
+                ))}
+              </div>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '.25rem', marginTop: '.5rem', fontSize: '.78rem', color: 'var(--dim)' }}>
+                {namedTargets.map(nt => (
+                  <div key={`${nt.source.name}->${nt.target.name}`}>
+                    {nt.icon} <strong style={{ color: 'var(--gold)' }}>{nt.label}</strong> fyrir {nt.source.name}: <span style={{ color: 'var(--text)' }}>{nt.target.name}</span>
+                  </div>
                 ))}
               </div>
             </div>

--- a/src/tabs/Suggester.jsx
+++ b/src/tabs/Suggester.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { detectSidePiles, detectHeirlooms, pickNamedTargets } from '../lib/sidePiles'
+import { SPLIT_PILE_MEMBERS } from '../constants'
 import CardImage from '../components/CardImage'
 import CardModal from '../components/CardModal'
 import DATA from '../data'
@@ -324,11 +325,14 @@ export default function Suggester() {
     const excludeCard = c =>
       (noAttacks && c.isAttack) || (noCurses && c.isCurseGiver) || (noTokens && c.isTokenCard)
 
-    // Kingdom cards only
+    // Kingdom cards only — exclude split-pile members (Herb Gatherer, Blacksmith,
+    // Sir Bailey, Humble Castle, …) since the parent pile (Augurs, Townsfolk,
+    // Knights, Castles) is what gets selected as the kingdom slot.
     const kingdomPool = cards.filter(c =>
       !c.removed &&
       !c.isSupplyCard &&
       (!c.card_type || c.card_type === 'Kingdom') &&
+      !SPLIT_PILE_MEMBERS.has(c.name) &&
       (selectedExps.length === 0 || selectedExps.includes(c.expansion)) &&
       !excludeCard(c)
     )


### PR DESCRIPTION
Surfaces every Dominion setup-time \"side piece\" the kingdom calls for: extra non-Supply piles, Heirlooms, and named targets like Way of the Mouse / Riverboat / Young Witch's Bane.

## What's covered

| Trigger | Side piece |
|---|---|
| Card text matches \`gain a Loot\` | Loots pile |
| \`gain a Spoils\` | Spoils pile |
| \`gain Ruins\` | Ruins pile |
| \`gain an Imp\` | Imps pile |
| \`gain a Spirit\` | Spirits pile |
| \`gain a Wish\` | Wishes pile |
| Hermit / Urchin / Tournament / Page / Peasant / Necromancer / Vampire / Black Market | Madman / Mercenary / Prizes / Travelers / Zombies / Bat / Black Market deck |
| Any Fate card (Druid, Bard, Pixie, Pooka, Sacred Grove, Skulk, Tracker, Idol) | Boons deck |
| Any Doom card (Cursed Village, Familiar, Idol, Leprechaun, Skulk, Tormentor, Vampire, Werewolf, Devil's Workshop) | Hexes deck |
| Cemetery / Fool / Pixie / Pooka / Secret Cave / Shepherd / Tracker | Heirloom (Haunted Mirror / Lucky Coin / Goat / Cursed Gold / Magic Lamp / Pasture / Pouch) |
| Way of the Mouse | Random non-attack Action costing \$2-\$3 from outside kingdom |
| Riverboat | Random non-attack Action costing \$5 from outside kingdom |
| Young Witch | Bane card — random Kingdom card costing \$3 from outside kingdom |

## Where it shows

- **Suggester**:
  - New \"Aukabunkar\" row for piles (icon + name chips)
  - New \"Auka kort\" row for named targets — kingdom-card tiles with explanatory pills (🐭 Mús-spil, 🚣 Bátsmaður-spil, 🧙 Bane)
  - Heirlooms shown as a gold 🎁 pill on the source kingdom card
  - Export text includes side piles, heirlooms, and named targets
- **GameModal**: side piles + heirloom pills shown for historical games. (No named-target reconstruction — that data isn't recorded.)

## Data check

23 of 120 historical games trigger at least one side piece. Example: game 51 picks up Imps + Spirits + Boons + Hexes + Shepherd=Pasture heirloom.

## Test plan

- [ ] Suggester: generate kingdoms until each trigger fires; verify the right pile / heirloom / named target shows.
- [ ] Suggester: copy export text and confirm side piles + heirlooms + targets appear in the output.
- [ ] History → game #51 modal: shows Aukabunkar (Imps, Spirits, Boons, Hexes) and gold heirloom pill on Shepherd.
- [ ] History → games without any side-piece-triggering cards: no Aukabunkar section.