### PR TITLE
Use Duration filter (not Attack) for Mouse/Riverboat targets

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -89,6 +89,14 @@ function isCurseGiver(text) {
   return /gains? a curse/i.test(text)
 }
 
+// Detect Duration cards from card text. Hallmarks: effects that span turns
+// — "at the start of your next/each turn", taking an extra turn (Outpost),
+// or effects "for the rest of the game" (Hireling).
+function isDurationCard(text) {
+  if (!text) return false
+  return /at the (start|beginning) of (your )?(next|each)( of your)? turn|now and at the start|while this is in play|take an extra turn|for the rest of (this|the) game/i.test(text)
+}
+
 // Victory cards whose +XVP is printed (not tokens) — excluded from token detection.
 const VICTORY_CARDS = new Set([
   'Gardens', 'Great Hall', 'Duke', 'Harem', 'Nobles', 'Island', 'Vineyard',
@@ -113,6 +121,7 @@ const rawCards = [...seenCardNames.values()].map(c => ({
   isSecondEdition: c.notes === '2nd edition',
   isAttack: isAttackCard(cardTexts[c.name]),
   isCurseGiver: isCurseGiver(cardTexts[c.name]),
+  isDuration: isDurationCard(cardTexts[c.name]),
   isTokenCard: isTokenCard(cardTexts[c.name], c),
 }))
 

--- a/src/lib/sidePiles.js
+++ b/src/lib/sidePiles.js
@@ -67,12 +67,12 @@ const NAMED_TARGETS = {
   'Way of the Mouse': {
     label: 'Mús-spil',
     icon: '🐭',
-    pool: c => [2, 3].includes(c.cost) && !c.isAttack,
+    pool: c => [2, 3].includes(c.cost) && !c.isDuration,
   },
   'Riverboat': {
     label: 'Bátsmaður-spil',
     icon: '🚣',
-    pool: c => c.cost === 5 && !c.isAttack,
+    pool: c => c.cost === 5 && !c.isDuration,
   },
   'Young Witch': {
     label: 'Bane',


### PR DESCRIPTION
Way of the Mouse and Riverboat both name a non-Duration Action card from outside the kingdom (Mouse: \$2-\$3, Riverboat: \$5). PR #33 had the filter wrong (\`!isAttack\` instead of \`!isDuration\`).

## Changes

- \`src/data.js\` — new \`isDurationCard()\` regex on card_text, fronts an \`isDuration\` flag on every card. Hits the standard Duration tells: \"at the start of your next/each turn\", \"now and at the start\", \"while this is in play\", \"take an extra turn\" (Outpost), \"for the rest of the game\" (Hireling).
- \`src/lib/sidePiles.js\` — Mouse and Riverboat target pools now filter on \`!c.isDuration\`.

## Spot-checked

Detection flagged correctly: Caravan, Wharf, Merchant Ship, Lighthouse, Haven, Outpost, Hireling, Cargo Ship, Tactician.
Did not flag: Smithy, Village, Witch, Royal Carriage (Reserve, not Duration).

## Test plan

- [ ] Generate kingdoms in the Suggester until Way of the Mouse appears; verify the named target is never a Duration card (no Caravan, Lighthouse, Haven at \$2-\$3).
- [ ] Same for Riverboat at \$5 (no Wharf, Merchant Ship).