### PR TITLE
Filters by location/player count + locations chart; reorder nav

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -51,10 +51,10 @@ export const SPLIT_PILE_MEMBERS = new Set([
 
 export const TABS = [
   { id: 'dashboard',   label: '📊 Yfirlit' },
+  { id: 'history',     label: '📖 Spilasaga' },
   { id: 'players',     label: '🏆 Leikmenn' },
   { id: 'cards',       label: '♣ Spil' },
   { id: 'expansions',  label: '📦 Viðbætur' },
-  { id: 'history',     label: '📖 Leikasaga' },
   { id: 'funfacts',    label: '🌟 Skemmtilegt' },
   { id: 'suggester',   label: '🎲 Ríkistillögur' },
 ]

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -134,6 +134,44 @@ export default function Dashboard({ onGameNav }) {
     }
   }, [])
 
+  const locationRef = useChart(() => {
+    const counts = {}
+    games.forEach(g => { if (g.location) counts[g.location] = (counts[g.location] || 0) + 1 })
+    const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1])
+    return {
+      type: 'bar',
+      data: {
+        labels: sorted.map(([loc]) => loc),
+        datasets: [{ data: sorted.map(([, v]) => v), backgroundColor: PALETTE.blue + '88', borderColor: PALETTE.blue, borderWidth: 1 }],
+      },
+      options: {
+        indexAxis: 'y',
+        maintainAspectRatio: false,
+        plugins: { legend: { display: false } },
+        scales: {
+          x: { ticks: { color: PALETTE.dim }, grid: { color: PALETTE.border } },
+          y: { ticks: { color: PALETTE.text, font: { size: 11 }, autoSkip: false }, grid: { display: false } },
+        },
+      },
+      plugins: [{
+        id: 'barLabels',
+        afterDatasetsDraw(chart) {
+          const { ctx } = chart
+          chart.data.datasets[0].data.forEach((value, i) => {
+            const bar = chart.getDatasetMeta(0).data[i]
+            ctx.save()
+            ctx.fillStyle = PALETTE.text
+            ctx.font = '11px sans-serif'
+            ctx.textAlign = 'left'
+            ctx.textBaseline = 'middle'
+            ctx.fillText(value, bar.x + 4, bar.y)
+            ctx.restore()
+          })
+        },
+      }],
+    }
+  }, [])
+
   const monthlyRef = useChart(() => {
     const counts = {}
     games.forEach(g => {
@@ -278,6 +316,12 @@ export default function Dashboard({ onGameNav }) {
         <h3>VINSÆLUSTU VIÐBÆTUR</h3>
         <div style={{ height: '420px', position: 'relative' }}>
           <canvas ref={expansionRef} />
+        </div>
+      </div>
+      <div className="chart-box" style={{ marginBottom: '1.5rem' }}>
+        <h3>VINSÆLUSTU STAÐIR</h3>
+        <div style={{ height: '300px', position: 'relative' }}>
+          <canvas ref={locationRef} />
         </div>
       </div>
       <div className="charts-row">

--- a/src/tabs/History.jsx
+++ b/src/tabs/History.jsx
@@ -74,7 +74,21 @@ export default function History({ targetGame, onClearTarget }) {
   const [filterPlayers, setFilterPlayers] = useState([])
   const [filterExp, setFilterExp] = useState('')
   const [filterVictory, setFilterVictory] = useState('')
+  const [filterLocation, setFilterLocation] = useState('')
+  const [filterPlayerCount, setFilterPlayerCount] = useState('')
   const [selectedGame, setSelectedGame] = useState(null)
+
+  const sortedLocations = useMemo(() => {
+    const counts = {}
+    for (const g of games) if (g.location) counts[g.location] = (counts[g.location] || 0) + 1
+    return Object.entries(counts).sort((a, b) => b[1] - a[1]).map(([name]) => name)
+  }, [games])
+
+  const playerCounts = useMemo(() => {
+    const set = new Set()
+    for (const g of games) if (g.players?.length) set.add(g.players.length)
+    return [...set].sort((a, b) => a - b)
+  }, [games])
 
   const highlights = useMemo(() => computeHighlights(games), [games])
   const { memoriesByGameNum, refetch } = useMemories()
@@ -94,6 +108,8 @@ export default function History({ targetGame, onClearTarget }) {
     if (filterPlayers.length > 0) list = list.filter(g => filterPlayers.every(p => g.results.some(r => r.name === p)))
     if (filterExp) list = list.filter(g => g.expansions.includes(filterExp))
     if (filterVictory) list = list.filter(g => g.victory_type === filterVictory)
+    if (filterLocation) list = list.filter(g => g.location === filterLocation)
+    if (filterPlayerCount) list = list.filter(g => g.players.length === Number(filterPlayerCount))
     if (search) {
       const q = search.toLowerCase()
       list = list.filter(g =>
@@ -103,7 +119,7 @@ export default function History({ targetGame, onClearTarget }) {
       )
     }
     return list
-  }, [sortedGames, search, filterPlayers, filterExp, filterVictory])
+  }, [sortedGames, search, filterPlayers, filterExp, filterVictory, filterLocation, filterPlayerCount])
 
   const victoryBadgeClass = {
     Province: 'badge-province',
@@ -130,7 +146,7 @@ export default function History({ targetGame, onClearTarget }) {
 
   return (
     <section className="section active">
-      <h2 className="section-title">Leikasaga</h2>
+      <h2 className="section-title">Spilasaga</h2>
 
       <div style={{ display: 'flex', gap: '.75rem', flexWrap: 'wrap', marginBottom: filterPlayers.length > 0 ? '.5rem' : '1rem', alignItems: 'center' }}>
         <input
@@ -158,6 +174,14 @@ export default function History({ targetGame, onClearTarget }) {
           <option value="Province">Héraðið</option>
           <option value="Colony">Nýlendur</option>
           <option value="Supply piles">Birgðahrúgar</option>
+        </select>
+        <select value={filterLocation} onChange={e => setFilterLocation(e.target.value)}>
+          <option value="">Allir staðir</option>
+          {sortedLocations.map(loc => <option key={loc} value={loc}>{loc}</option>)}
+        </select>
+        <select value={filterPlayerCount} onChange={e => setFilterPlayerCount(e.target.value)}>
+          <option value="">Allir leikmannafjöldar</option>
+          {playerCounts.map(n => <option key={n} value={n}>{n}-manna</option>)}
         </select>
       </div>
 


### PR DESCRIPTION
Closes #23.

## Changes

- **Nav**: Spilasaga (history) moved to position 2 right after Yfirlit. Tab renamed from \"Leikasaga\" to \"Spilasaga\" while moving it.
- **History tab**: two new dropdowns next to the existing search/players/expansion/victory filters
  - Allir staðir → filter by venue (sorted by game count)
  - Allir leikmannafjöldar → filter by N-manna (2/3/4/5/6 etc., from data)
- **Dashboard**: new \"Vinsælustu staðir\" horizontal bar chart below the expansions chart, in blue, with on-bar count labels.

## Test plan

- [ ] Nav order is Yfirlit · Spilasaga · Leikmenn · Spil · Viðbætur · Skemmtilegt · Ríkistillögur.
- [ ] Spilasaga: pick a location → only games at that venue. Pick a player count → only N-manna games. Combine with player/expansion/victory filters.
- [ ] Dashboard: locations chart renders with all distinct venues sorted by count.