### PR TITLE
Locations doughnut chart + canonicalize venue declensions

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -4,8 +4,17 @@ import cardTexts from '../data/card_texts.json'
 // ── Normalize & parse all games ───────────────────────────────────────────────
 const PLAYER_FIXES = { 'Hallgríur': 'Hallgrímur' }
 const EXP_FIXES = { 'Cornucopia': 'Cornucopia & Guilds', 'Prospoerity': 'Prosperity', 'Rising sun': 'Rising Sun', 'Dark ages': 'Dark Ages' }
+// Icelandic case declensions of the same place — collapse to nominative.
+const LOCATION_FIXES = {
+  'Laugarási': 'Laugarás',
+  'Húsafelli': 'Húsafell',
+  'Arnarholti': 'Arnarholt',
+  'Álfheimum': 'Álfheimar',
+  'Laugalæk 23': 'Laugalækur',
+}
 const fixName = n => PLAYER_FIXES[n] || n
 const fixExp = e => EXP_FIXES[e] || e
+const fixLocation = l => l ? (LOCATION_FIXES[l] || l) : l
 
 // Build canonical card name map (lowercase → proper case) from card list
 const canonicalCardName = new Map()
@@ -50,6 +59,7 @@ const parsedGames = rawData.games
       ...g,
       ...extras,
       victory_type,
+      location: fixLocation(g.location),
       players: g.players.map(fixName),
       results: g.results.map(r => ({ ...r, name: fixName(r.name) })),
       expansions: (g.expansions || []).map(fixExp),

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -135,40 +135,41 @@ export default function Dashboard({ onGameNav }) {
   }, [])
 
   const locationRef = useChart(() => {
+    const MIN = 3
     const counts = {}
     games.forEach(g => { if (g.location) counts[g.location] = (counts[g.location] || 0) + 1 })
     const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1])
+    const big = sorted.filter(([, v]) => v >= MIN)
+    const small = sorted.filter(([, v]) => v < MIN)
+    const otherTotal = small.reduce((sum, [, v]) => sum + v, 0)
+    const otherLabel = `Annað (${small.length} staðir)`
+    const slices = otherTotal > 0 ? [...big, [otherLabel, otherTotal]] : big
+    const colors = slices.map((_, i) => `hsl(${Math.round(i * 360 / slices.length)}, 60%, 55%)`)
     return {
-      type: 'bar',
+      type: 'doughnut',
       data: {
-        labels: sorted.map(([loc]) => loc),
-        datasets: [{ data: sorted.map(([, v]) => v), backgroundColor: PALETTE.blue + '88', borderColor: PALETTE.blue, borderWidth: 1 }],
+        labels: slices.map(([loc]) => loc),
+        datasets: [{ data: slices.map(([, v]) => v), backgroundColor: colors, borderWidth: 0 }],
       },
       options: {
-        indexAxis: 'y',
         maintainAspectRatio: false,
-        plugins: { legend: { display: false } },
-        scales: {
-          x: { ticks: { color: PALETTE.dim }, grid: { color: PALETTE.border } },
-          y: { ticks: { color: PALETTE.text, font: { size: 11 }, autoSkip: false }, grid: { display: false } },
+        plugins: {
+          legend: { position: 'right', labels: { color: PALETTE.text, font: { size: 11 }, boxWidth: 12 } },
+          tooltip: {
+            callbacks: {
+              label: (ctx) => {
+                const label = ctx.label || ''
+                const value = ctx.parsed
+                if (label === otherLabel) {
+                  return [`${value} leikir alls`, ...small.map(([n, v]) => `  ${n}: ${v}`)]
+                }
+                return `${value} leikir`
+              },
+            },
+          },
         },
+        cutout: '55%',
       },
-      plugins: [{
-        id: 'barLabels',
-        afterDatasetsDraw(chart) {
-          const { ctx } = chart
-          chart.data.datasets[0].data.forEach((value, i) => {
-            const bar = chart.getDatasetMeta(0).data[i]
-            ctx.save()
-            ctx.fillStyle = PALETTE.text
-            ctx.font = '11px sans-serif'
-            ctx.textAlign = 'left'
-            ctx.textBaseline = 'middle'
-            ctx.fillText(value, bar.x + 4, bar.y)
-            ctx.restore()
-          })
-        },
-      }],
     }
   }, [])
 


### PR DESCRIPTION
## Summary

- Convert *Vinsælustu staðir* from a horizontal bar chart to a doughnut. Venues with fewer than 3 games roll up into a single **Annað (N staðir)** slice; hovering that slice in the tooltip lists every grouped venue with its individual count.
- Canonicalize Icelandic case declensions of the same venue at the data-load layer:
  - Laugarási → Laugarás
  - Húsafelli → Húsafell
  - Arnarholti → Arnarholt
  - Álfheimum → Álfheimar
  - Laugalæk 23 → Laugalækur
- Affects every site that consumes \`game.location\`: the new doughnut, History filter dropdown, FunFacts *Heimavöllur* fact.

## Net diff

\`src/data.js\` (+8/-2), \`src/tabs/Dashboard.jsx\` (+27/-22).

## Test plan

- [ ] Dashboard: doughnut shows ~6-7 named venues + Annað. Selvogsgrunn dominates as expected.
- [ ] Hover Annað → tooltip lists every small venue with its count.
- [ ] History filter dropdown: Laugarás appears once (was twice), same for Húsafell, Arnarholt, Álfheimar, Laugalækur.
- [ ] FunFacts → Heimavöllur fact still picks the correct top location (Selvogsgrunn).