### PR TITLE
Trim expansions chart height; locations as pie with side labels

### DIFF
--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -331,7 +331,7 @@ export default function Dashboard({ onGameNav }) {
       </div>
       <div className="chart-box" style={{ marginBottom: '1.5rem' }}>
         <h3>VINSÆLUSTU VIÐBÆTUR</h3>
-        <div style={{ height: '420px', position: 'relative' }}>
+        <div style={{ height: '300px', position: 'relative' }}>
           <canvas ref={expansionRef} />
         </div>
       </div>

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -143,28 +143,24 @@ export default function Dashboard({ onGameNav }) {
     const small = sorted.filter(([, v]) => v < MIN)
     const otherTotal = small.reduce((sum, [, v]) => sum + v, 0)
     const otherLabel = `Annað (${small.length} staðir)`
-    const rows = otherTotal > 0 ? [...big, [otherLabel, otherTotal]] : big
+    const slices = otherTotal > 0 ? [...big, [otherLabel, otherTotal]] : big
+    const colors = slices.map((_, i) => `hsl(${Math.round(i * 360 / slices.length)}, 60%, 55%)`)
     return {
-      type: 'bar',
+      type: 'pie',
       data: {
-        labels: rows.map(([loc]) => loc),
-        datasets: [{
-          data: rows.map(([, v]) => v),
-          backgroundColor: PALETTE.blue + '88',
-          borderColor: PALETTE.blue,
-          borderWidth: 1,
-        }],
+        labels: slices.map(([loc]) => loc),
+        datasets: [{ data: slices.map(([, v]) => v), backgroundColor: colors, borderWidth: 0 }],
       },
       options: {
-        indexAxis: 'y',
         maintainAspectRatio: false,
+        layout: { padding: { top: 16, bottom: 16, left: 90, right: 90 } },
         plugins: {
           legend: { display: false },
           tooltip: {
             callbacks: {
               label: (ctx) => {
                 const label = ctx.label || ''
-                const value = ctx.parsed.x
+                const value = ctx.parsed
                 if (label === otherLabel) {
                   return [`${value} leikir alls`, ...small.map(([n, v]) => `  ${n}: ${v}`)]
                 }
@@ -173,23 +169,34 @@ export default function Dashboard({ onGameNav }) {
             },
           },
         },
-        scales: {
-          x: { ticks: { color: PALETTE.dim }, grid: { color: PALETTE.border } },
-          y: { ticks: { color: PALETTE.text, font: { size: 11 }, autoSkip: false }, grid: { display: false } },
-        },
       },
       plugins: [{
-        id: 'barLabels',
+        id: 'sliceLabels',
         afterDatasetsDraw(chart) {
           const { ctx } = chart
-          chart.data.datasets[0].data.forEach((value, i) => {
-            const bar = chart.getDatasetMeta(0).data[i]
+          const meta = chart.getDatasetMeta(0)
+          meta.data.forEach((arc, i) => {
+            const value = chart.data.datasets[0].data[i]
+            if (!value) return
+            const angle = (arc.startAngle + arc.endAngle) / 2
+            const r = arc.outerRadius + 8
+            const x = arc.x + Math.cos(angle) * r
+            const y = arc.y + Math.sin(angle) * r
+            const tickEndX = arc.x + Math.cos(angle) * (arc.outerRadius + 4)
+            const tickEndY = arc.y + Math.sin(angle) * (arc.outerRadius + 4)
             ctx.save()
+            ctx.strokeStyle = PALETTE.dim
+            ctx.lineWidth = 1
+            ctx.beginPath()
+            ctx.moveTo(arc.x + Math.cos(angle) * arc.outerRadius, arc.y + Math.sin(angle) * arc.outerRadius)
+            ctx.lineTo(tickEndX, tickEndY)
+            ctx.stroke()
             ctx.fillStyle = PALETTE.text
             ctx.font = '11px sans-serif'
-            ctx.textAlign = 'left'
+            ctx.textAlign = x < arc.x ? 'right' : 'left'
             ctx.textBaseline = 'middle'
-            ctx.fillText(value, bar.x + 4, bar.y)
+            const label = chart.data.labels[i]
+            ctx.fillText(`${label} (${value})`, x, y)
             ctx.restore()
           })
         },

--- a/src/tabs/Dashboard.jsx
+++ b/src/tabs/Dashboard.jsx
@@ -143,23 +143,28 @@ export default function Dashboard({ onGameNav }) {
     const small = sorted.filter(([, v]) => v < MIN)
     const otherTotal = small.reduce((sum, [, v]) => sum + v, 0)
     const otherLabel = `Annað (${small.length} staðir)`
-    const slices = otherTotal > 0 ? [...big, [otherLabel, otherTotal]] : big
-    const colors = slices.map((_, i) => `hsl(${Math.round(i * 360 / slices.length)}, 60%, 55%)`)
+    const rows = otherTotal > 0 ? [...big, [otherLabel, otherTotal]] : big
     return {
-      type: 'doughnut',
+      type: 'bar',
       data: {
-        labels: slices.map(([loc]) => loc),
-        datasets: [{ data: slices.map(([, v]) => v), backgroundColor: colors, borderWidth: 0 }],
+        labels: rows.map(([loc]) => loc),
+        datasets: [{
+          data: rows.map(([, v]) => v),
+          backgroundColor: PALETTE.blue + '88',
+          borderColor: PALETTE.blue,
+          borderWidth: 1,
+        }],
       },
       options: {
+        indexAxis: 'y',
         maintainAspectRatio: false,
         plugins: {
-          legend: { position: 'right', labels: { color: PALETTE.text, font: { size: 11 }, boxWidth: 12 } },
+          legend: { display: false },
           tooltip: {
             callbacks: {
               label: (ctx) => {
                 const label = ctx.label || ''
-                const value = ctx.parsed
+                const value = ctx.parsed.x
                 if (label === otherLabel) {
                   return [`${value} leikir alls`, ...small.map(([n, v]) => `  ${n}: ${v}`)]
                 }
@@ -168,8 +173,27 @@ export default function Dashboard({ onGameNav }) {
             },
           },
         },
-        cutout: '55%',
+        scales: {
+          x: { ticks: { color: PALETTE.dim }, grid: { color: PALETTE.border } },
+          y: { ticks: { color: PALETTE.text, font: { size: 11 }, autoSkip: false }, grid: { display: false } },
+        },
       },
+      plugins: [{
+        id: 'barLabels',
+        afterDatasetsDraw(chart) {
+          const { ctx } = chart
+          chart.data.datasets[0].data.forEach((value, i) => {
+            const bar = chart.getDatasetMeta(0).data[i]
+            ctx.save()
+            ctx.fillStyle = PALETTE.text
+            ctx.font = '11px sans-serif'
+            ctx.textAlign = 'left'
+            ctx.textBaseline = 'middle'
+            ctx.fillText(value, bar.x + 4, bar.y)
+            ctx.restore()
+          })
+        },
+      }],
     }
   }, [])
 


### PR DESCRIPTION
Two Dashboard polish tweaks driven by feedback after PR #37.

## Summary

- **Vinsælustu viðbætur**: chart height 420px → 300px (matches the locations chart). Bars are still readable for the 17 expansion entries.
- **Vinsælustu staðir**: switched from horizontal bars (PR #35) → doughnut (PR #36) → and now a pie with **venue names + counts drawn around each slice** via a custom \`afterDatasetsDraw\` plugin. Side legend is hidden. The \`Annað (N staðir)\` rollup and its hover-expand tooltip are preserved.

## Net diff

Single file: \`src/tabs/Dashboard.jsx\` — ~30 lines.

## Test plan

- [ ] Vinsælustu viðbætur visibly shorter, still readable.
- [ ] Vinsælustu staðir: pie with venue name + count next to each slice on a leader tick.
- [ ] Annað slice: hover shows the list of small venues with individual counts.