### PR TITLE
Allow choosing memory highlight at upload time

### DIFF
--- a/src/components/MemoryEditor.jsx
+++ b/src/components/MemoryEditor.jsx
@@ -43,10 +43,15 @@ export default function MemoryEditor({ game, existingMemory, onSave, onCancel })
 
   const handleFiles = (files) => {
     const imageFiles = Array.from(files).filter((f) => f.type.startsWith('image/'))
-    const withPreview = imageFiles.map((file) => ({
+    if (imageFiles.length === 0) return
+    // Auto-star the first new upload when nothing is currently highlighted —
+    // saves a click for the common "upload some photos, mark the best one" flow.
+    const hasAnyHighlight = photos.some((p) => p.highlight) || newFiles.some((f) => f.highlight)
+    const withPreview = imageFiles.map((file, idx) => ({
       file,
       preview: URL.createObjectURL(file),
       taggedPlayers: [],
+      highlight: !hasAnyHighlight && idx === 0,
     }))
     setNewFiles((prev) => [...prev, ...withPreview])
   }
@@ -87,11 +92,23 @@ export default function MemoryEditor({ game, existingMemory, onSave, onCancel })
     })
   }
 
-  const toggleHighlight = (index) => {
+  // The highlight is "one per memory" — toggling it on one image must clear
+  // it on every other, across BOTH existing photos and pending uploads.
+  const setHighlight = (kind, index) => {
+    const currentlyOn = kind === 'existing'
+      ? !!photos[index]?.highlight
+      : !!newFiles[index]?.highlight
+    const next = !currentlyOn
     setPhotos((prev) =>
       prev.map((p, i) => ({
         ...p,
-        highlight: i === index ? !p.highlight : false,
+        highlight: kind === 'existing' && i === index ? next : false,
+      }))
+    )
+    setNewFiles((prev) =>
+      prev.map((f, i) => ({
+        ...f,
+        highlight: kind === 'new' && i === index ? next : false,
       }))
     )
   }
@@ -145,6 +162,7 @@ export default function MemoryEditor({ game, existingMemory, onSave, onCancel })
           gameNum: game.game_num,
           caption: newFiles[i].caption || null,
           taggedPlayers: fileTags,
+          highlight: !!newFiles[i].highlight,
           order: photos.length + i,
         })
       }
@@ -257,7 +275,7 @@ export default function MemoryEditor({ game, existingMemory, onSave, onCancel })
                 </div>
                 <div style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }}>
                   <button
-                    onClick={() => toggleHighlight(i)}
+                    onClick={() => setHighlight('existing', i)}
                     title={photo.highlight ? 'Fjarlægja úr korti' : 'Sýna á korti'}
                     style={{
                       background: 'none', border: '1px solid var(--border)',
@@ -333,13 +351,24 @@ export default function MemoryEditor({ game, existingMemory, onSave, onCancel })
                     }}
                   />
                 </div>
-                <button
-                  onClick={() => removeNewFile(i)}
-                  style={{
-                    background: 'none', border: '1px solid var(--border)', color: 'var(--red)',
-                    borderRadius: '3px', cursor: 'pointer', fontSize: '0.7rem', padding: '2px 5px',
-                  }}
-                >✕</button>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: '0.2rem' }}>
+                  <button
+                    onClick={() => setHighlight('new', i)}
+                    title={f.highlight ? 'Fjarlægja úr korti' : 'Sýna á korti'}
+                    style={{
+                      background: 'none', border: '1px solid var(--border)',
+                      color: f.highlight ? 'var(--gold)' : 'var(--dim)',
+                      borderRadius: '3px', cursor: 'pointer', fontSize: '0.7rem', padding: '2px 5px',
+                    }}
+                  >{f.highlight ? '★' : '☆'}</button>
+                  <button
+                    onClick={() => removeNewFile(i)}
+                    style={{
+                      background: 'none', border: '1px solid var(--border)', color: 'var(--red)',
+                      borderRadius: '3px', cursor: 'pointer', fontSize: '0.7rem', padding: '2px 5px',
+                    }}
+                  >✕</button>
+                </div>
               </div>
             </div>
           ))}


### PR DESCRIPTION
## Summary
- Add ★/☆ button to new-file previews in `MemoryEditor` so the highlight can be set before the memory is saved.
- Auto-star the first uploaded image when nothing is currently highlighted (saves a click for the common "upload some photos, mark the best one" flow).
- Unify highlight toggling so it clears stars across both existing photos and pending uploads, preserving the one-highlight-per-memory invariant.
- Persist the `highlight` flag on uploaded photos at save time (previously dropped).

## Test plan
- [ ] Open the memory editor for a game with no existing memory; upload several images → first one is starred automatically.
- [ ] Click ★ on a different new upload → star moves to that file.
- [ ] Open an existing memory with a highlighted photo and upload a new image → no auto-star (existing highlight remains).
- [ ] Star a new upload in that case → existing photo's star is cleared.
- [ ] Save and reopen the memory → the star you chose at upload time is still set.