### PR TITLE
Read both projects when a game has two on the same row

### DIFF
--- a/data/dominion_data.json
+++ b/data/dominion_data.json
@@ -10652,7 +10652,8 @@
       "events": [],
       "landmarks": [],
       "projects": [
-        "Barracks"
+        "Barracks",
+        "Citadel"
       ],
       "ways": [],
       "allies": [],
@@ -19603,6 +19604,6 @@
     "Laugalæk 23": 1,
     "Álfheimar": 1
   },
-  "last_updated": "2026-05-13 15:05",
+  "last_updated": "2026-05-13 15:26",
   "upcoming_games": 0
 }

--- a/scripts/sync_spreadsheet.py
+++ b/scripts/sync_spreadsheet.py
@@ -176,6 +176,39 @@ def parse_string_rows(ws, col, rows):
     return values
 
 
+# Source-expansion tags (e.g. 'Renaissance') sit in col+1 of single-name rows
+# to mark which expansion a project/way/trait comes from. They look like names
+# but should not be treated as project names.
+KNOWN_EXPANSION_TAGS = frozenset({
+    'dominion', 'intrigue', 'seaside', 'alchemy', 'prosperity',
+    'prospoerity', 'cornucopia', 'guilds', 'cornucopia & guilds',
+    'hinterlands', 'dark ages', 'adventures', 'empires', 'nocturne',
+    'renaissance', 'menagerie', 'allies', 'plunder', 'rising sun',
+})
+
+
+def is_expansion_tag(val):
+    return isinstance(val, str) and val.strip().lower() in KNOWN_EXPANSION_TAGS
+
+
+def parse_projects(ws, col):
+    """Parse the projects row (24).
+
+    A game may have more than one project, in which case the second is
+    written into the next column of the same row. col+1 historically holds
+    the source-expansion tag (e.g. 'Renaissance') when there is only one
+    project, so we read every cell and drop expansion tags — both projects
+    survive regardless of which column the user happened to use.
+    """
+    names = []
+    for offset in (0, 1, 2):
+        val = read_string_cell(ws, ROW_PROJECT, col + offset)
+        if val is None or is_expansion_tag(val):
+            continue
+        names.append(val)
+    return names
+
+
 def parse_traits(ws, col):
     """Parse the trait row.
 
@@ -333,7 +366,7 @@ def parse_game(ws, game_num, col):
     kingdom = parse_kingdom(ws, col)
     events = parse_string_rows(ws, col, [ROW_EVENT_1, ROW_EVENT_2])
     landmarks = parse_string_rows(ws, col, [ROW_LANDMARK_1, ROW_LANDMARK_2])
-    projects = parse_string_rows(ws, col, [ROW_PROJECT])
+    projects = parse_projects(ws, col)
     ways = parse_string_rows(ws, col, [ROW_WAY])
     allies = parse_string_rows(ws, col, [ROW_ALLY_1, ROW_ALLY_2])
     traits = parse_traits(ws, col)


### PR DESCRIPTION
## Summary
- Game 117 has two Renaissance Projects (Barracks + Citadel) entered side-by-side in row 24, but the sync script only read `col+0` so Citadel was dropped.
- Read `col+0..col+2` of the project row and filter out cells matching a known Dominion expansion name (those are source-expansion tags, e.g. `'Renaissance'` in `col+1` of single-project games).
- Diff vs. previous sync output: only game 117 changes (`['Barracks']` → `['Barracks', 'Citadel']`). Every other game's project list is identical.

Fixes the bug Guðmundur reported: "Leikur 117, tvö Project (í sömu línu en ekki dálki) en bara annað talið."

## Test plan
- [x] Re-run `python3 scripts/sync_spreadsheet.py` against the current spreadsheet, compare `dominion_data.json` before/after — only game 117 changes.
- [ ] Open game 117 in the deployed app, confirm both Barracks and Citadel show in the Projects list.