### PR TITLE
Clean bogus card entries and fix misspelled card names

### DIFF
--- a/data/dominion_data.json
+++ b/data/dominion_data.json
@@ -17335,7 +17335,7 @@
       "isSecondEdition": false
     },
     {
-      "name": "Domination",
+      "name": "Dominate",
       "expansion": "Empires",
       "cost": 0,
       "debt": 12,
@@ -18559,42 +18559,6 @@
       "isSecondEdition": false
     },
     {
-      "name": "Guild of Travelers",
-      "expansion": "Allies",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Ally",
-      "isSecondEdition": false
-    },
-    {
-      "name": "Harbor League",
-      "expansion": "Allies",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Ally",
-      "isSecondEdition": false
-    },
-    {
-      "name": "Helpers",
-      "expansion": "Allies",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Ally",
-      "isSecondEdition": false
-    },
-    {
       "name": "Island Folk",
       "expansion": "Allies",
       "cost": 0,
@@ -18620,18 +18584,6 @@
     },
     {
       "name": "League of Shopkeepers",
-      "expansion": "Allies",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Ally",
-      "isSecondEdition": false
-    },
-    {
-      "name": "Marketeers",
       "expansion": "Allies",
       "cost": 0,
       "debt": null,
@@ -18692,18 +18644,6 @@
     },
     {
       "name": "Plateau Shepherds",
-      "expansion": "Allies",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Ally",
-      "isSecondEdition": false
-    },
-    {
-      "name": "Rabble Rousers",
       "expansion": "Allies",
       "cost": 0,
       "debt": null,
@@ -18835,18 +18775,6 @@
       "isSecondEdition": false
     },
     {
-      "name": "Lazy",
-      "expansion": "Plunder",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Trait",
-      "isSecondEdition": false
-    },
-    {
       "name": "Nearby",
       "expansion": "Plunder",
       "cost": 0,
@@ -18872,30 +18800,6 @@
     },
     {
       "name": "Pious",
-      "expansion": "Plunder",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Trait",
-      "isSecondEdition": false
-    },
-    {
-      "name": "Portly",
-      "expansion": "Plunder",
-      "cost": 0,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Trait",
-      "isSecondEdition": false
-    },
-    {
-      "name": "Profane",
       "expansion": "Plunder",
       "cost": 0,
       "debt": null,
@@ -19255,7 +19159,7 @@
       "isSecondEdition": false
     },
     {
-      "name": "Spellscroll",
+      "name": "Spell Scroll",
       "expansion": "Plunder",
       "cost": 0,
       "debt": null,
@@ -19306,18 +19210,6 @@
       "name": "Acolyte",
       "expansion": "Allies",
       "cost": 4,
-      "debt": null,
-      "potion": false,
-      "notes": null,
-      "times_used": 0,
-      "removed": false,
-      "card_type": "Kingdom",
-      "isSecondEdition": false
-    },
-    {
-      "name": "Amulet of Wishes",
-      "expansion": "Allies",
-      "cost": 6,
       "debt": null,
       "potion": false,
       "notes": null,


### PR DESCRIPTION
## Summary
The `cards` array in `dominion_data.json` had 11 entries that don't correspond to real Dominion cards (confirmed against the wiki). Nine of them aren't referenced by any game and are removed outright:

- Amulet of Wishes
- Lazy, Portly, Profane (not real Plunder Traits)
- Guild of Travelers, Harbor League, Helpers, Marketeers, Rabble Rousers (not real Allies)

Two are real cards stored under wrong names and are renamed in place:

- `Spellscroll` → `Spell Scroll` (Plunder Loot)
- `Domination` → `Dominate` (Empires Event)

## Companion changes outside this diff
Already executed against the bucket so the new names resolve once this lands:
- Uploaded `cards/Spell_Scroll.jpg` and `cards/Dominate.jpg` (fetched from the wiki).
- Renamed two filename typos: `cards/Transmongrify.jpg` → `Transmogrify.jpg`, `cards/Harbringer.jpg` → `Harbinger.jpg` (data already used the correct spellings; the bucket had the typo).

## Test plan
- [x] `npm run build` clean.
- [ ] Open the Cards tab; confirm the 9 removed names no longer appear and `Spell Scroll` / `Dominate` show with images.
- [ ] Game 96 (`Transmogrify` in kingdom) and games 26/43/57/114 (`Harbinger` in kingdom) load their card images.

## Follow-up (separate, owner: Guðmundur)
Three spreadsheet-side typos in game data — to be fixed in the source sheet so the next sync clears them: `Acqueduct` → `Aqueduct` (game 98 landmark), `Jewelled Egg` → `Jeweled Egg` (game 41 kingdom), `Archictects' guild` → `Architects' Guild` (game 105 allies).